### PR TITLE
Overlay header on hero and tidy footer

### DIFF
--- a/footer.html
+++ b/footer.html
@@ -3,7 +3,7 @@
   <div class="container footer-grid">
     <div>
      <a class="brand" href="index.html">
-      <img id="site-logo" src="favicon.svg" alt="Nortek Roofing logo" class="logo">
+      <img src="favicon.svg" alt="Nortek Roofing logo" class="logo site-logo">
     </a>
       <p class="muted small" id="service-areas">Greater Victoria</p>
       <p class="muted small"><a id="footer-phone" href="tel:000">250-000-0000</a><br><a id="footer-email" href="mailto:info@example.com">info@example.com</a></p>

--- a/header.html
+++ b/header.html
@@ -2,7 +2,7 @@
 <header class="site-header">
   <div class="container header-inner">
     <a class="brand" href="index.html">
-      <img id="site-logo" src="favicon.svg" alt="Nortek Roofing logo" class="logo">
+      <img src="favicon.svg" alt="Nortek Roofing logo" class="logo site-logo">
     </a>
     <nav class="nav" id="nav">
       <a href="projects.html">Projects</a>

--- a/includes.js
+++ b/includes.js
@@ -10,8 +10,8 @@ async function applyConfig(){
   const cfg = await fetch('data/site-config.json').then(r => r.json()).catch(()=>null);
   if (!cfg) return;
   // header
-  const logo = document.getElementById('site-logo');
-  if (logo && cfg.logo) logo.src = cfg.logo;
+  const logos = document.querySelectorAll('.site-logo');
+  if (cfg.logo) logos.forEach(l => l.src = cfg.logo);
   const brand = document.getElementById('brand-name');
   if (brand && cfg.company) brand.textContent = cfg.company;
 

--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="style.css" />
 </head>
-<body>
+<body class="home">
 
   <div id="site-header"></div>
 

--- a/style.css
+++ b/style.css
@@ -7,13 +7,14 @@
 html,body{margin:0;padding:0;background:var(--bg);color:var(--text);font-family:Inter,system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif;line-height:1.6}
 a{color:var(--text);text-decoration:none}
 img{max-width:100%;height:auto;display:block}
+main{padding-top:var(--header-h)}body.home main{padding-top:0}
 .container{max-width:1100px;margin:0 auto;padding:0 20px}
 .small{font-size:.92rem}.muted{color:var(--muted)}
 .rounded{border-radius:14px}.shadow{box-shadow:0 10px 30px rgba(0,0,0,.35)}
 h1,h2,h3{line-height:1.2}
 
 /* Header */
-.site-header{position:sticky;top:0;z-index:10;background:rgba(15,18,21,.7);backdrop-filter:blur(18px);border-bottom:1px solid #1f2730}
+.site-header{position:fixed;top:0;left:0;width:100%;z-index:10;background:rgba(15,18,21,.7);backdrop-filter:blur(18px);border-bottom:1px solid #1f2730}
 .header-inner{display:flex;align-items:center;justify-content:space-between;padding:14px 0}
 .brand{display:flex;gap:10px;align-items:center;font-weight:700}
 .logo{width:90px;height:auto;border-radius:6px}
@@ -25,9 +26,9 @@ h1,h2,h3{line-height:1.2}
 .btn.ghost{background:transparent}
 
 /* Hero video */
-.hero-video{position:relative;width:100%;height:calc(100svh - var(--header-h));margin-top:var(--header-h);overflow:hidden;background:#0d1217;border-bottom:1px solid #1f2730}
-@supports (height:100dvh){ .hero-video{ height:calc(100dvh - var(--header-h)); } }
-@supports not (height:100svh){ .hero-video{ height:calc(100vh - var(--header-h)); } }
+.hero-video{position:relative;width:100%;height:100svh;overflow:hidden;background:#0d1217;border-bottom:1px solid #1f2730}
+@supports (height:100dvh){ .hero-video{ height:100dvh; } }
+@supports not (height:100svh){ .hero-video{ height:100vh; } }
 .hero-video .hero-bg{position:absolute;inset:0;width:100%;height:100%;object-fit:cover;filter:brightness(.6);z-index:0}
 .hero-overlay{position:absolute;inset:0;z-index:1;display:flex;flex-direction:column;align-items:center;justify-content:center;text-align:center;padding:0 20px}
 .hero-overlay > *{max-width:min(900px,92vw)}
@@ -95,6 +96,8 @@ h1,h2,h3{line-height:1.2}
 .lightbox img{max-width:90vw;max-height:85vh;border-radius:12px}
 
 /* Footer */
+.site-footer{padding:48px 0}
+.site-footer .brand{margin-bottom:12px}
 .site-footer .footer-grid{display:grid;grid-template-columns:1fr 1fr 1fr;gap:18px}
 .footer-bottom{padding:12px 0;border-top:1px solid #22303a;margin-top:18px}
 


### PR DESCRIPTION
## Summary
- Make header fixed and overlay the hero video
- Full-viewport hero video with no offset; internal pages padded for fixed header
- Add footer spacing and update logo handling across header and footer

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689d08fa79bc8325b11f04573f53399b