### PR TITLE
Expand layout to full width

### DIFF
--- a/style.css
+++ b/style.css
@@ -8,7 +8,7 @@ html,body{margin:0;padding:0;background:var(--bg);color:var(--text);font-family:
 a{color:var(--text);text-decoration:none}
 img{max-width:100%;height:auto;display:block}
 main{padding-top:var(--header-h)}body.home main{padding-top:0}
-.container{max-width:1100px;margin:0 auto;padding:0 20px}
+.container{width:100%;margin:0 auto;padding:0 20px}
 .small{font-size:.92rem}.muted{color:var(--muted)}
 .rounded{border-radius:14px}.shadow{box-shadow:0 10px 30px rgba(0,0,0,.35)}
 h1,h2,h3{line-height:1.2}
@@ -31,9 +31,9 @@ h1,h2,h3{line-height:1.2}
 @supports not (height:100svh){ .hero-video{ height:100vh; } }
 .hero-video .hero-bg{position:absolute;inset:0;width:100%;height:100%;object-fit:cover;filter:brightness(.6);z-index:0}
 .hero-overlay{position:absolute;inset:0;z-index:1;display:flex;flex-direction:column;align-items:center;justify-content:center;text-align:center;padding:0 20px}
-.hero-overlay > *{max-width:min(900px,92vw)}
+.hero-overlay > *{width:100%}
 .hero-overlay h1{font-size:clamp(2rem,4vw,3rem);margin:0 0 1rem}
-.hero-overlay p{max-width:760px;margin:0 0 1.0rem}
+.hero-overlay p{width:100%;margin:0 0 1.0rem}
 .cta-row{display:flex;gap:12px;flex-wrap:wrap;justify-content:center;margin:10px 0 0}
 
 /* Opaque Glass Button */


### PR DESCRIPTION
## Summary
- Allow `.container` elements to span full screen width
- Remove max-width limits on hero content so hero text can use full width

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f816d9e2483259dfa8bada65c8b89