### PR TITLE
Make hero scroll cue subtle

### DIFF
--- a/script.js
+++ b/script.js
@@ -10,3 +10,9 @@ if (v){
   window.addEventListener('touchstart', kick, { passive:true });
   window.addEventListener('scroll', kick, { passive:true });
 }
+
+// Subtle scroll cue
+const cue = document.querySelector('.glass-cue');
+if (cue) {
+  setTimeout(() => cue.classList.add('show'), 5000);
+}

--- a/style.css
+++ b/style.css
@@ -57,12 +57,37 @@ h1,h2,h3{line-height:1.2}
   transform: translateY(-2px);
 }
 /* Glass Scroll Arrow */
-.glass-cue{position:static;margin-top:18px;border:1px solid rgba(255,255,255,.28);background:rgba(255,255,255,.08);backdrop-filter:blur(14px) saturate(160%);-webkit-backdrop-filter:blur(14px) saturate(160%);border-radius:999px;width:58px;height:58px;display:grid;place-items:center;cursor:pointer;box-shadow:inset 0 1px 0 rgba(255,255,255,.22),0 10px 26px rgba(0,0,0,.35)}
-.glass-cue:hover{filter:brightness(1.05)}
-.glass-cue__arrow{position:relative;width:18px;height:18px;display:block}
-.glass-cue__arrow::before,.glass-cue__arrow::after{content:"";position:absolute;left:50%;transform:translateX(-50%);border-radius:2px}
-.glass-cue__arrow::before{width:2px;height:18px;top:0;background:#fff}
-.glass-cue__arrow::after{width:10px;height:10px;bottom:1px;border-right:2px solid #fff;border-bottom:2px solid #fff;transform:translateX(-50%) rotate(45deg)}
+.glass-cue{
+  position:absolute;
+  bottom:20px;
+  left:50%;
+  transform:translateX(-50%);
+  margin-top:0;
+  border:none;
+  background:transparent;
+  width:32px;
+  height:32px;
+  display:grid;
+  place-items:center;
+  cursor:pointer;
+  opacity:0;
+  pointer-events:none;
+  transition:opacity .6s;
+}
+.glass-cue.show{
+  opacity:.35;
+  pointer-events:auto;
+}
+.glass-cue__arrow{position:relative;width:12px;height:12px;display:block}
+.glass-cue__arrow::before,.glass-cue__arrow::after{
+  content:"";
+  position:absolute;
+  left:50%;
+  transform:translateX(-50%);
+  border-radius:1px;
+}
+.glass-cue__arrow::before{width:2px;height:12px;top:0;background:rgba(255,255,255,.8)}
+.glass-cue__arrow::after{width:8px;height:8px;bottom:0;border-right:2px solid rgba(255,255,255,.8);border-bottom:2px solid rgba(255,255,255,.8);transform:translateX(-50%) rotate(45deg)}
 
 /* Sections */
 .section{padding:64px 0;border-bottom:1px solid #1f2730}


### PR DESCRIPTION
## Summary
- Tone down hero scroll cue appearance and reposition at bottom of screen
- Fade in scroll cue after 5 seconds to gently suggest scrolling

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_689f84ced7bc83259e477a00ebbe9146