### PR TITLE
Tweak layout padding and header opacity

### DIFF
--- a/style.css
+++ b/style.css
@@ -8,13 +8,13 @@ html,body{margin:0;padding:0;background:var(--bg);color:var(--text);font-family:
 a{color:var(--text);text-decoration:none}
 img{max-width:100%;height:auto;display:block}
 main{padding-top:var(--header-h)}body.home main{padding-top:0}
-.container{width:100%;margin:0 auto;padding:0 20px}
+.container{width:100%;margin:0 auto;padding:0 clamp(20px,5vw,60px)}
 .small{font-size:.92rem}.muted{color:var(--muted)}
 .rounded{border-radius:14px}.shadow{box-shadow:0 10px 30px rgba(0,0,0,.35)}
 h1,h2,h3{line-height:1.2}
 
 /* Header */
-.site-header{position:fixed;top:0;left:0;width:100%;z-index:10;background:rgba(15,18,21,.7);backdrop-filter:blur(18px);border-bottom:1px solid #1f2730}
+.site-header{position:fixed;top:0;left:0;width:100%;z-index:10;background:var(--bg);border-bottom:1px solid #1f2730}
 .header-inner{display:flex;align-items:center;justify-content:space-between;padding:14px 0}
 .brand{display:flex;gap:10px;align-items:center;font-weight:700}
 .logo{width:90px;height:auto;border-radius:6px}


### PR DESCRIPTION
## Summary
- Provide responsive horizontal padding for header and footer
- Make the header fully opaque to match site background

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f86a8a7b48325afd69e8888c7df01