### PR TITLE
feat: add hover overlay for project titles

### DIFF
--- a/projects.html
+++ b/projects.html
@@ -23,7 +23,7 @@
       grid.innerHTML = list.map(p => \`
         <a href="project.html?id=\${encodeURIComponent(p.id)}">
           <img src="\${p.cover}" alt="\${p.title}">
-          <div class="feature-meta" style="padding:10px"><h3>\${p.title}</h3></div>
+          <div class="feature-meta"><h3>\${p.title}</h3></div>
         </a>\`
       ).join('');
     });

--- a/services-commercial.html
+++ b/services-commercial.html
@@ -28,7 +28,7 @@
       grid.innerHTML = list.map(p => \`
         <a href="project.html?id=\${encodeURIComponent(p.id)}">
           <img src="\${p.cover}" alt="\${p.title}">
-          <div class="feature-meta" style="padding:10px"><h3>\${p.title}</h3></div>
+          <div class="feature-meta"><h3>\${p.title}</h3></div>
         </a>\`
       ).join('');
     });

--- a/style.css
+++ b/style.css
@@ -96,8 +96,9 @@ h1,h2,h3{line-height:1.2}
 .grid.cards{display:grid;grid-template-columns:repeat(4,1fr);gap:18px}
 .card{background:var(--surface);border:1px solid #222c36;border-radius:16px;padding:18px}
 .grid.featured{display:grid;grid-template-columns:repeat(3,1fr);gap:18px}
-.feature-card{background:var(--surface);border:1px solid #222c36;border-radius:16px;overflow:hidden;display:block}
-.feature-meta{padding:12px 14px}
+.feature-card{background:var(--surface);border:1px solid #222c36;border-radius:16px;overflow:hidden;display:block;position:relative}
+.feature-meta{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;text-align:center;padding:12px 14px;background:rgba(0,0,0,.55);opacity:0;transition:opacity .3s ease;pointer-events:none}
+.feature-card:hover .feature-meta,.projects-grid a:hover .feature-meta{opacity:1}
 .about-split{display:grid;grid-template-columns:1.2fr .8fr;gap:18px;align-items:center}
 
 /* Services landing */
@@ -112,7 +113,7 @@ h1,h2,h3{line-height:1.2}
 
 /* Projects grid */
 .projects-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:16px}
-.projects-grid a{display:block;border:1px solid #22303a;border-radius:14px;overflow:hidden;background:#0d1217}
+.projects-grid a{display:block;border:1px solid #22303a;border-radius:14px;overflow:hidden;background:#0d1217;position:relative}
 .projects-grid img{width:100%;height:200px;object-fit:cover;display:block}
 
 /* Lightbox */


### PR DESCRIPTION
## Summary
- add fade-in overlay to show project titles when hovering project images
- remove inline feature-meta padding in project grids

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689f89e5e7c083259445d469bda44675