### PR TITLE
Add video and descriptions to project pages

### DIFF
--- a/data/projects.json
+++ b/data/projects.json
@@ -3,64 +3,104 @@
     "id": "proj1",
     "title": "Project 1",
     "cover": "images/proj-1.jpg",
+    "video": "hero.mp4",
+    "description": "Brief description for Project 1.",
     "media": [
-      "images/proj-1.jpg"
+      "images/proj-1.jpg",
+      "images/hero-1.jpg",
+      "images/hero-2.jpg",
+      "images/hero-3.jpg"
     ]
   },
   {
     "id": "proj2",
     "title": "Project 2",
     "cover": "images/proj-2.jpg",
+    "video": "hero.mp4",
+    "description": "Brief description for Project 2.",
     "media": [
-      "images/proj-2.jpg"
+      "images/proj-2.jpg",
+      "images/hero-1.jpg",
+      "images/hero-2.jpg",
+      "images/hero-3.jpg"
     ]
   },
   {
     "id": "proj3",
     "title": "Project 3",
     "cover": "images/proj-3.jpg",
+    "video": "hero.mp4",
+    "description": "Brief description for Project 3.",
     "media": [
-      "images/proj-3.jpg"
+      "images/proj-3.jpg",
+      "images/hero-1.jpg",
+      "images/hero-2.jpg",
+      "images/hero-3.jpg"
     ]
   },
   {
     "id": "proj4",
     "title": "Project 4",
     "cover": "images/proj-4.jpg",
+    "video": "hero.mp4",
+    "description": "Brief description for Project 4.",
     "media": [
-      "images/proj-4.jpg"
+      "images/proj-4.jpg",
+      "images/hero-1.jpg",
+      "images/hero-2.jpg",
+      "images/hero-3.jpg"
     ]
   },
   {
     "id": "proj5",
     "title": "Project 5",
     "cover": "images/proj-5.jpg",
+    "video": "hero.mp4",
+    "description": "Brief description for Project 5.",
     "media": [
-      "images/proj-5.jpg"
+      "images/proj-5.jpg",
+      "images/hero-1.jpg",
+      "images/hero-2.jpg",
+      "images/hero-3.jpg"
     ]
   },
   {
     "id": "proj6",
     "title": "Project 6",
     "cover": "images/proj-6.jpg",
+    "video": "hero.mp4",
+    "description": "Brief description for Project 6.",
     "media": [
-      "images/proj-6.jpg"
+      "images/proj-6.jpg",
+      "images/hero-1.jpg",
+      "images/hero-2.jpg",
+      "images/hero-3.jpg"
     ]
   },
   {
     "id": "proj7",
     "title": "Project 7",
     "cover": "images/proj-7.jpg",
+    "video": "hero.mp4",
+    "description": "Brief description for Project 7.",
     "media": [
-      "images/proj-7.jpg"
+      "images/proj-7.jpg",
+      "images/hero-1.jpg",
+      "images/hero-2.jpg",
+      "images/hero-3.jpg"
     ]
   },
   {
     "id": "proj8",
     "title": "Project 8",
     "cover": "images/proj-8.jpg",
+    "video": "hero.mp4",
+    "description": "Brief description for Project 8.",
     "media": [
-      "images/proj-8.jpg"
+      "images/proj-8.jpg",
+      "images/hero-1.jpg",
+      "images/hero-2.jpg",
+      "images/hero-3.jpg"
     ]
   }
 ]

--- a/project.html
+++ b/project.html
@@ -11,6 +11,8 @@
     <section class="section">
       <div class="container">
         <h1 id="proj-title" class="section-title">Project</h1>
+        <video id="proj-video" class="project-video" controls playsinline></video>
+        <p id="proj-desc" class="project-desc"></p>
         <div id="proj-media" class="projects-grid" style="grid-template-columns:repeat(3,1fr)"></div>
       </div>
     </section>
@@ -27,8 +29,16 @@
       const proj = list.find(p => p.id === id) || list[0];
       document.getElementById('proj-title').textContent = proj.title;
       document.getElementById('page-title').textContent = proj.title + ' — Nortek Roofing';
+      const vid = document.getElementById('proj-video');
+      if(proj.video){
+        vid.src = proj.video;
+        vid.poster = proj.cover;
+      } else {
+        vid.style.display = 'none';
+      }
+      document.getElementById('proj-desc').textContent = proj.description || '';
       const grid = document.getElementById('proj-media');
-      grid.innerHTML = (proj.media || []).map(src => \`<a href="\${src}" class="tile"><img src="\${src}" alt=""></a>\`).join('');
+      grid.innerHTML = (proj.media || []).map(src => `\n        <a href="${src}" class="tile"><img src="${src}" alt=""></a>`).join('');
       const lb = document.getElementById('lightbox');
       const lbImg = document.getElementById('lightbox-img');
       grid.addEventListener('click', e => {

--- a/style.css
+++ b/style.css
@@ -115,6 +115,8 @@ h1,h2,h3{line-height:1.2}
 .projects-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:16px}
 .projects-grid a{display:block;border:1px solid #22303a;border-radius:14px;overflow:hidden;background:#0d1217;position:relative}
 .projects-grid img{width:100%;height:200px;object-fit:cover;display:block}
+.project-video{width:100%;max-height:500px;border-radius:14px;margin-bottom:16px;background:#000}
+.project-desc{margin:16px 0}
 
 /* Lightbox */
 .lightbox{position:fixed;inset:0;background:rgba(0,0,0,.8);display:none;align-items:center;justify-content:center;z-index:50}


### PR DESCRIPTION
## Summary
- extend project data with video sources, descriptions and image galleries
- display project video, description and gallery on dedicated project page
- style project video and description sections

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689f8a9cdd688325b1d9572fa0aa82c6