### PR TITLE
Add team and careers pages

### DIFF
--- a/about.html
+++ b/about.html
@@ -10,6 +10,33 @@
         <p>We’re a Vancouver Island roofing company focused on commercial and residential flat & low‑slope systems.</p>
       </div>
     </section>
+    <section class="section alt">
+      <div class="container">
+        <h2 class="section-title">Our Team</h2>
+        <div class="grid cards">
+          <div class="card">
+            <img src="https://via.placeholder.com/300" alt="Alex Johnson"/>
+            <h3>Alex Johnson</h3>
+            <p class="muted small">Owner</p>
+          </div>
+          <div class="card">
+            <img src="https://via.placeholder.com/300" alt="Taylor Smith"/>
+            <h3>Taylor Smith</h3>
+            <p class="muted small">Project Manager</p>
+          </div>
+          <div class="card">
+            <img src="https://via.placeholder.com/300" alt="Jordan Lee"/>
+            <h3>Jordan Lee</h3>
+            <p class="muted small">Estimator</p>
+          </div>
+          <div class="card">
+            <img src="https://via.placeholder.com/300" alt="Casey Patel"/>
+            <h3>Casey Patel</h3>
+            <p class="muted small">Foreman</p>
+          </div>
+        </div>
+      </div>
+    </section>
   </main>
   <div id="site-footer"></div>
   <script src="includes.js"></script>

--- a/careers.html
+++ b/careers.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<html lang="en">
+<head><meta charset="utf-8"/><meta name="viewport" content="width=device-width,initial-scale=1"/><title>Careers — Nortek Roofing</title><link rel="stylesheet" href="style.css"/></head>
+<body>
+  <div id="site-header"></div>
+  <main>
+    <section class="section">
+      <div class="container">
+        <h1 class="section-title">Careers</h1>
+        <p>Join our growing team. Browse our current openings below.</p>
+        <div class="grid cards">
+          <div class="card">
+            <h3>Experienced Roofer</h3>
+            <p class="muted small">Full-time</p>
+            <p>We’re looking for roofers with at least 3 years of experience in flat and low-slope systems.</p>
+            <p><a class="btn primary" href="mailto:info@example.com">Apply Now</a></p>
+          </div>
+          <div class="card">
+            <h3>Apprentice Roofer</h3>
+            <p class="muted small">Full-time</p>
+            <p>Start your roofing career with us. No experience required.</p>
+            <p><a class="btn primary" href="mailto:info@example.com">Apply Now</a></p>
+          </div>
+        </div>
+      </div>
+    </section>
+  </main>
+  <div id="site-footer"></div>
+  <script src="includes.js"></script>
+</body>
+</html>

--- a/footer.html
+++ b/footer.html
@@ -10,7 +10,7 @@
     </div>
     <div>
       <h5>Learn More</h5>
-      <p class="footer-links"><a href="services.html">Services</a> · <a href="about.html">About</a> · <a href="projects.html">Projects</a></p>
+      <p class="footer-links"><a href="services.html">Services</a> · <a href="about.html">About</a> · <a href="projects.html">Projects</a> · <a href="careers.html">Careers</a></p>
     </div>
     <div>
       <h5>Get a Quote</h5>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -8,4 +8,5 @@
   <url><loc>https://www.nortekroofing.ca/about.html</loc></url>
   <url><loc>https://www.nortekroofing.ca/contact.html</loc></url>
   <url><loc>https://www.nortekroofing.ca/privacy.html</loc></url>
+  <url><loc>https://www.nortekroofing.ca/careers.html</loc></url>
 </urlset>


### PR DESCRIPTION
## Summary
- expand About page with team section and placeholder profiles
- introduce Careers page with job postings
- link Careers from footer and update sitemap

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f9004fe9c8325969a0236f55b2aed