### PR TITLE
Replace circular scroll cue with standalone 3D arrow

### DIFF
--- a/style.css
+++ b/style.css
@@ -62,37 +62,47 @@ h1,h2,h3{line-height:1.2}
   bottom:20px;
   left:50%;
   transform:translateX(-50%);
-  margin-top:0;
-  border:1px solid rgba(255,255,255,0.18);
-  background:rgba(255,255,255,0.08);
-  width:44px;
-  height:44px;
-  display:grid;
-  place-items:center;
+  width:28px;
+  height:28px;
+  display:block;
   cursor:pointer;
   opacity:0;
   pointer-events:none;
-  border-radius:50%;
-  box-shadow:inset 0 1px 2px rgba(255,255,255,0.3),0 4px 10px rgba(0,0,0,0.25);
-  backdrop-filter:blur(8px);
-  -webkit-backdrop-filter:blur(8px);
   transition:opacity .6s;
 }
 .glass-cue.show{
-  opacity:.55;
+  opacity:.85;
   pointer-events:auto;
   animation:cueBounce 2.4s ease-in-out infinite;
 }
-.glass-cue__arrow{position:relative;width:16px;height:16px;display:block}
-.glass-cue__arrow::before,.glass-cue__arrow::after{
+.glass-cue__arrow{
+  position:relative;
+  width:100%;
+  height:100%;
+  display:block;
+}
+.glass-cue__arrow::before,
+.glass-cue__arrow::after{
   content:"";
   position:absolute;
   left:50%;
   transform:translateX(-50%);
-  border-radius:1px;
+  box-shadow:0 2px 2px rgba(0,0,0,0.35);
 }
-.glass-cue__arrow::before{width:2px;height:12px;top:0;background:rgba(255,255,255,.85)}
-.glass-cue__arrow::after{width:8px;height:8px;bottom:0;border-right:2px solid rgba(255,255,255,.85);border-bottom:2px solid rgba(255,255,255,.85);transform:translateX(-50%) rotate(45deg)}
+.glass-cue__arrow::before{
+  top:0;
+  width:6px;
+  height:14px;
+  background:linear-gradient(to right,#e8edf2,#cdd9e5);
+  border-radius:2px;
+}
+.glass-cue__arrow::after{
+  bottom:0;
+  width:20px;
+  height:20px;
+  background:linear-gradient(to bottom right,#e8edf2,#cdd9e5);
+  clip-path:polygon(50% 100%,0 0,100% 0);
+}
 
 @keyframes cueBounce{
   0%,100%{transform:translate(-50%,0)}


### PR DESCRIPTION
## Summary
- restyle scroll cue so the arrow itself is clickable and displayed without surrounding circle
- add subtle gradient and shadow for a 3D appearance while retaining bounce animation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689f916819cc8325a2005908fbc2df8a