### PR TITLE
Add enterprise homepage sections and animations

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,6 +10,15 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="style.css" />
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "RoofingContractor",
+    "name": "Nortek Roofing",
+    "url": "https://nortekroofing.example",
+    "areaServed": ["Victoria BC", "Westshore BC", "Nanaimo BC"]
+  }
+  </script>
 </head>
 <body class="home">
 
@@ -34,32 +43,133 @@
       </div>
     </section>
 
-    <section class="section">
+    <!-- Section 1: Impact Statement + Quick Stats -->
+    <section class="section impact" aria-labelledby="impact-heading">
       <div class="container">
-        <h2 class="section-title">Featured Projects</h2>
-        <div class="grid featured">
-          <a class="feature-card" href="projects.html">
-            <img src="images/proj-1.jpg" alt="Retail rooftop" loading="lazy">
-            <div class="feature-meta">
-              <h3>Boulderhouse Climbing</h3>
-            </div>
+        <h2 id="impact-heading" class="section-title">Building &amp; Protecting Large-Scale Roofs Across the West Coast</h2>
+        <div class="stats-grid">
+          <div class="stat reveal">
+            <span class="stat-number">25+ Years</span>
+            <span class="stat-label">Delivering Complex Projects</span>
+          </div>
+          <div class="stat reveal">
+            <span class="stat-number">5M+ sq ft</span>
+            <span class="stat-label">Installed</span>
+          </div>
+          <div class="stat reveal">
+            <span class="stat-number">180k sq ft</span>
+            <span class="stat-label">Largest Single Project</span>
+          </div>
+          <div class="stat reveal">
+            <span class="stat-number">Licensed • Insured</span>
+            <span class="stat-label">COR-Aligned Safety</span>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Section 2: Signature Projects Showcase -->
+    <section class="section projects" aria-labelledby="projects-heading">
+      <div class="container">
+        <h2 id="projects-heading" class="section-title">Signature Projects</h2>
+        <div class="showcase-grid">
+          <a href="images/proj-1.jpg" class="project-tile reveal">
+            <img src="images/proj-1.jpg" alt="Boulderhouse Climbing project" loading="lazy" decoding="async">
+            <div class="project-meta"><h3>Boulderhouse Climbing</h3><p class="small">Recreation • 45k sq ft</p></div>
           </a>
-          <a class="feature-card" href="projects.html">
-            <img src="images/proj-2.jpg" alt="Strata roof" loading="lazy">
-            <div class="feature-meta">
-              <h3>Hull's Corner Business Park</h3>
-            </div>
+          <a href="images/proj-2.jpg" class="project-tile reveal">
+            <img src="images/proj-2.jpg" alt="Hull's Corner Business Park" loading="lazy" decoding="async">
+            <div class="project-meta"><h3>Hull's Corner Business Park</h3><p class="small">Commercial • 60k sq ft</p></div>
           </a>
-          <a class="feature-card" href="projects.html">
-            <img src="images/proj-3.jpg" alt="Industrial building" loading="lazy">
-            <div class="feature-meta">
-              <h3>Meaford Avenue Apartments</h3>
-            </div>
+          <a href="images/proj-3.jpg" class="project-tile reveal">
+            <img src="images/proj-3.jpg" alt="Meaford Avenue Apartments" loading="lazy" decoding="async">
+            <div class="project-meta"><h3>Meaford Avenue Apartments</h3><p class="small">Multi-Residential • 90k sq ft</p></div>
+          </a>
+          <a href="images/proj-4.jpg" class="project-tile reveal">
+            <img src="images/proj-4.jpg" alt="Industrial complex project" loading="lazy" decoding="async">
+            <div class="project-meta"><h3>Industrial Complex</h3><p class="small">Industrial • 80k sq ft</p></div>
+          </a>
+          <a href="images/proj-5.jpg" class="project-tile reveal">
+            <img src="images/proj-5.jpg" alt="Retail distribution center" loading="lazy" decoding="async">
+            <div class="project-meta"><h3>Distribution Centre</h3><p class="small">Logistics • 120k sq ft</p></div>
+          </a>
+          <a href="images/proj-6.jpg" class="project-tile reveal">
+            <img src="images/proj-6.jpg" alt="Institutional roof" loading="lazy" decoding="async">
+            <div class="project-meta"><h3>Institutional Facility</h3><p class="small">Institutional • 75k sq ft</p></div>
           </a>
         </div>
       </div>
     </section>
+
+    <!-- Section 3: Why Nortek Pillars -->
+    <section class="section pillars" aria-labelledby="pillars-heading">
+      <div class="container">
+        <h2 id="pillars-heading" class="section-title">Why Nortek</h2>
+        <div class="pillars-grid">
+          <div class="pillar-card reveal">
+            <h3>Safety &amp; Compliance at Scale</h3>
+            <p class="small">Dedicated safety teams and COR-aligned procedures.</p>
+          </div>
+          <div class="pillar-card reveal">
+            <h3>On-Time, On-Budget Delivery</h3>
+            <p class="small">Rigorous scheduling and cost control for predictability.</p>
+          </div>
+          <div class="pillar-card reveal">
+            <h3>Complex Detailing &amp; QA</h3>
+            <p class="small">Experienced crews tackling intricate details and quality assurance.</p>
+          </div>
+          <div class="pillar-card reveal">
+            <h3>Coordination with GCs &amp; Consultants</h3>
+            <p class="small">Transparent communication with project stakeholders.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Section 4: Process Timeline -->
+    <section class="section process" aria-labelledby="process-heading">
+      <div class="container">
+        <h2 id="process-heading" class="section-title">Process</h2>
+        <ol class="process-steps">
+          <li class="process-step reveal"><h3 class="step-title">Assessment &amp; Scope</h3></li>
+          <li class="process-step reveal"><h3 class="step-title">Planning &amp; Safety</h3></li>
+          <li class="process-step reveal"><h3 class="step-title">Execution &amp; QA</h3></li>
+          <li class="process-step reveal"><h3 class="step-title">Turnover &amp; Documentation</h3></li>
+          <li class="process-step reveal"><h3 class="step-title">Maintenance Programs</h3></li>
+        </ol>
+      </div>
+    </section>
+
+    <!-- Section 5: CTA Band -->
+    <section class="section cta-band alt" aria-labelledby="cta-heading">
+      <div class="container">
+        <h3 id="cta-heading">Ready to discuss a project?</h3>
+        <p class="muted">Enterprise roofing solutions for the West Coast.</p>
+        <div class="cta-actions">
+          <a class="btn primary" href="contact.html">Discuss a Project</a>
+          <a class="btn glass" href="projects.html">View Projects</a>
+        </div>
+      </div>
+    </section>
+
+    <!-- Section 6: Service Area Map + Areas -->
+    <section class="section service-area" aria-labelledby="area-heading">
+      <div class="container">
+        <h2 id="area-heading" class="section-title">Service Area</h2>
+        <div class="service-area__content">
+          <img src="images/service-area.jpg" alt="Map of service areas" loading="lazy" decoding="async">
+          <ul class="areas-list">
+            <li>Victoria</li>
+            <li>Westshore</li>
+            <li>Nanaimo</li>
+            <li>Surrounding Regions</li>
+          </ul>
+        </div>
+      </div>
+    </section>
   </main>
+
+  <div class="lightbox" id="lightbox"><img id="lightbox-img" alt=""></div>
 
   <div id="site-footer"></div>
 

--- a/script.js
+++ b/script.js
@@ -16,3 +16,31 @@ const cue = document.querySelector('.glass-cue');
 if (cue) {
   setTimeout(() => cue.classList.add('show'), 5000);
 }
+
+document.addEventListener('DOMContentLoaded', () => {
+  if (!window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+    const io = new IntersectionObserver(entries => {
+      entries.forEach(entry => {
+        if (entry.isIntersecting) {
+          entry.target.classList.add('visible');
+          io.unobserve(entry.target);
+        }
+      });
+    }, { threshold: 0.2 });
+    document.querySelectorAll('.reveal').forEach(el => io.observe(el));
+  }
+
+  const grid = document.querySelector('.showcase-grid');
+  const lb = document.getElementById('lightbox');
+  const lbImg = document.getElementById('lightbox-img');
+  if (grid && lb && lbImg) {
+    grid.addEventListener('click', e => {
+      const a = e.target.closest('a.project-tile');
+      if (!a) return;
+      e.preventDefault();
+      lbImg.src = a.href;
+      lb.classList.add('open');
+    });
+    lb.addEventListener('click', () => lb.classList.remove('open'));
+  }
+});

--- a/style.css
+++ b/style.css
@@ -173,3 +173,42 @@ h1,h2,h3{line-height:1.2}
   .nav{display:none;position:absolute;right:20px;top:58px;background:#0d1217;border:1px solid #23303a;border-radius:12px;padding:10px;width:220px;flex-direction:column}
   .nav.open{display:flex}
 }
+
+/* HOMEPAGE SECTIONS */
+.stats-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:20px;text-align:center}
+.stat{background:var(--surface);border:1px solid #222c36;border-radius:16px;padding:24px}
+.stat-number{display:block;font-size:1.6rem;font-weight:700;margin-bottom:4px}
+.showcase-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:16px}
+.project-tile{position:relative;display:block;border:1px solid #222c36;border-radius:16px;overflow:hidden;transition:transform .3s,filter .3s}
+.project-tile img{width:100%;height:100%;aspect-ratio:4/3;object-fit:cover;display:block}
+.project-meta{position:absolute;left:0;right:0;bottom:0;padding:12px;background:rgba(0,0,0,.55)}
+.project-tile:hover,.project-tile:focus{transform:translateY(-2px);filter:brightness(1.05)}
+.project-tile:focus-visible{outline:2px solid var(--brand);outline-offset:2px}
+.pillars-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:18px}
+.pillar-card{background:var(--surface);border:1px solid #222c36;border-radius:16px;padding:24px}
+.process-steps{display:flex;gap:20px;list-style:none;margin:0;padding:0}
+.process-step{flex:1;text-align:center;background:var(--surface);border:1px solid #222c36;border-radius:16px;padding:20px;position:relative}
+.process-step + .process-step::before{content:"";position:absolute;left:-10px;top:50%;width:20px;height:1px;background:#222c36}
+.cta-band{text-align:center}
+.cta-actions{margin-top:18px;display:flex;gap:12px;flex-wrap:wrap;justify-content:center}
+.service-area__content{display:flex;align-items:center;gap:24px}
+.service-area__content img{max-width:500px;border-radius:16px;border:1px solid #222c36}
+.areas-list{list-style:none;margin:0;padding:0}
+.reveal{opacity:0;transform:translateY(16px);transition:opacity .3s ease,transform .3s ease}
+.reveal.visible{opacity:1;transform:none}
+.full-bleed{width:100vw;position:relative;left:50%;right:50%;margin-left:-50vw;margin-right:-50vw}
+@media (max-width:980px){
+  .stats-grid{grid-template-columns:repeat(2,1fr)}
+  .pillars-grid{grid-template-columns:repeat(2,1fr)}
+  .process-steps{flex-direction:column}
+  .service-area__content{flex-direction:column}
+}
+@media (max-width:640px){
+  .stats-grid{grid-template-columns:1fr}
+  .showcase-grid{grid-template-columns:1fr}
+  .pillars-grid{grid-template-columns:1fr}
+}
+@media (prefers-reduced-motion:reduce){
+  .reveal{opacity:1;transform:none;transition:none}
+  .project-tile:hover,.project-tile:focus{transform:none;filter:none}
+}


### PR DESCRIPTION
## Summary
- add impact statement, project showcase, value pillars, process timeline, CTA band, and service area sections
- implement subtle intersection observer reveals and lightbox for project tiles
- append styles for new sections and responsive layouts with existing theme

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f94601d1083259b7e53e6aa5036d3