### PR TITLE
Fix footer positioning and shrink copyright

### DIFF
--- a/footer.html
+++ b/footer.html
@@ -19,6 +19,6 @@
     </div>
   </div>
   <div class="container footer-bottom">
-    <p>© <span id="year">2025</span> <span id="footer-brand-inline">Nortek Roofing</span>. All rights reserved. · <a href="privacy.html">Privacy</a></p>
+    <p class="copyright muted">© <span id="year">2025</span> <span id="footer-brand-inline">Nortek Roofing</span>. All rights reserved. · <a href="privacy.html">Privacy</a></p>
   </div>
 </footer>

--- a/style.css
+++ b/style.css
@@ -4,10 +4,12 @@
   --header-h: 64px;
 }
 *{box-sizing:border-box}
-html,body{margin:0;padding:0;background:var(--bg);color:var(--text);font-family:Inter,system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif;line-height:1.6}
+html,body{margin:0;padding:0;background:var(--bg);color:var(--text);font-family:Inter,system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif;line-height:1.6;min-height:100vh}
+body{display:flex;flex-direction:column}
 a{color:var(--text);text-decoration:none}
 img{max-width:100%;height:auto;display:block}
-main{padding-top:var(--header-h)}body.home main{padding-top:0}
+main{padding-top:var(--header-h);flex:1}
+body.home main{padding-top:0}
 .container{width:100%;margin:0 auto;padding:0 clamp(20px,5vw,60px)}
 .small{font-size:.92rem}.muted{color:var(--muted)}
 .rounded{border-radius:14px}.shadow{box-shadow:0 10px 30px rgba(0,0,0,.35)}
@@ -143,10 +145,11 @@ h1,h2,h3{line-height:1.2}
 .lightbox img{max-width:90vw;max-height:85vh;border-radius:12px}
 
 /* Footer */
-.site-footer{padding:48px 0}
+.site-footer{padding:48px 0;margin-top:auto}
 .site-footer .brand{margin-bottom:12px}
 .site-footer .footer-grid{display:grid;grid-template-columns:1fr 1fr 1fr;gap:18px}
 .footer-bottom{padding:12px 0;border-top:1px solid #22303a;margin-top:18px}
+.footer-bottom .copyright{font-size:.75rem}
 
 /* Responsive */
 @media (max-width: 980px){


### PR DESCRIPTION
## Summary
- Flex layout ensures footer sticks to bottom of short pages
- Reduce copyright text size and mute its color

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f97ec4cec8325975e640692ebbabf