### PR TITLE
Animate hero text with typewriter transition

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,11 +19,11 @@
       <video id="heroVideo" class="hero-bg" autoplay muted playsinline webkit-playsinline loop preload="metadata" poster="images/hero-poster.jpg">
         <source src="hero.mp4" type="video/mp4">
       </video>
-      <div class="hero-overlay">
-        <h1>Built for the West Coast.</h1>
-        <div class="cta-row">
-          <a class="btn glass" href="services.html">Explore Services</a>
-        </div>
+        <div class="hero-overlay">
+          <h1 id="heroText">Built for the West Coast.</h1>
+          <div class="cta-row">
+            <a id="exploreBtn" class="btn glass" href="services.html">Explore Services</a>
+          </div>
         <div class="cta-row">
           <div class="glass-cue" aria-label="Scroll to content"
             onclick="document.querySelector('main .section')?.scrollIntoView({behavior:'smooth'})">

--- a/script.js
+++ b/script.js
@@ -11,6 +11,46 @@ if (v){
   window.addEventListener('scroll', kick, { passive:true });
 }
 
+// Hero text typewriter effect
+const heroText = document.getElementById('heroText');
+const exploreBtn = document.getElementById('exploreBtn');
+if (heroText && exploreBtn) {
+  const first = 'Built for the West Coast.';
+  const replace = 'West Coast.';
+  const second = 'Island.';
+  const speed = 100;
+  heroText.textContent = '';
+
+  const type = (text, cb) => {
+    let i = 0;
+    const step = () => {
+      if (i < text.length) {
+        heroText.textContent += text[i++];
+        setTimeout(step, speed);
+      } else if (cb) cb();
+    };
+    step();
+  };
+
+  const del = (count, cb) => {
+    const step = () => {
+      if (count > 0) {
+        heroText.textContent = heroText.textContent.slice(0, -1);
+        count--;
+        setTimeout(step, speed);
+      } else if (cb) cb();
+    };
+    step();
+  };
+
+  setTimeout(() => type(first), 3000);
+  setTimeout(() => {
+    del(replace.length, () => {
+      type(second, () => exploreBtn.classList.add('show'));
+    });
+  }, 18000);
+}
+
 // Subtle scroll cue
 const cue = document.querySelector('.glass-cue');
 if (cue) {

--- a/style.css
+++ b/style.css
@@ -37,6 +37,8 @@ h1,h2,h3{line-height:1.2}
 .hero-overlay h1{font-size:clamp(2rem,4vw,3rem);margin:0 0 1rem}
 .hero-overlay p{width:100%;margin:0 0 1.0rem}
 .cta-row{display:flex;gap:12px;flex-wrap:wrap;justify-content:center;margin:10px 0 0}
+#exploreBtn{opacity:0;pointer-events:none;transition:opacity .6s ease}
+#exploreBtn.show{opacity:1;pointer-events:auto}
 
 /* Opaque Glass Button */
 .btn.glass {


### PR DESCRIPTION
## Summary
- Add typewriter animation to hero heading that swaps "West Coast" for "Island" midway through the video
- Fade in "Explore Services" button after final phrase completes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689f9b13d0908325ba10d74ca8446b0a