### PR TITLE
Reduce island transition delay

### DIFF
--- a/script.js
+++ b/script.js
@@ -48,7 +48,7 @@ if (heroText && exploreBtn) {
     del(replace.length, () => {
       type(second, () => exploreBtn.classList.add('show'));
     });
-  }, 18000);
+  }, 7000);
 }
 
 // Subtle scroll cue


### PR DESCRIPTION
## Summary
- shorten delay before switching hero text from "West Coast" to "Island"

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f9e8db57c8325beb2aa63c81940b2