### PR TITLE
Smooth explore button fade-in transition

### DIFF
--- a/script.js
+++ b/script.js
@@ -46,7 +46,7 @@ if (heroText && exploreBtn) {
   setTimeout(() => type(first), 3000);
   setTimeout(() => {
     del(replace.length, () => {
-      type(second, () => exploreBtn.classList.add('show'));
+        type(second, () => setTimeout(() => exploreBtn.classList.add('show'), 100));
     });
   }, 18000);
 }

--- a/style.css
+++ b/style.css
@@ -37,7 +37,7 @@ h1,h2,h3{line-height:1.2}
 .hero-overlay h1{font-size:clamp(2rem,4vw,3rem);margin:0 0 1rem}
 .hero-overlay p{width:100%;margin:0 0 1.0rem}
 .cta-row{display:flex;gap:12px;flex-wrap:wrap;justify-content:center;margin:10px 0 0}
-#exploreBtn{opacity:0;pointer-events:none;transition:opacity .6s ease}
+#exploreBtn{opacity:0;pointer-events:none;transition:opacity 1.2s ease}
 #exploreBtn.show{opacity:1;pointer-events:auto}
 
 /* Opaque Glass Button */


### PR DESCRIPTION
## Summary
- extend explore button opacity transition to 1.2s for a smoother appearance
- add slight delay before showing the button to match the eased transition

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f9e90bb5c8325a9612bb49e03caf4