### PR TITLE
Start hero text animation sooner

### DIFF
--- a/script.js
+++ b/script.js
@@ -43,12 +43,14 @@ if (heroText && exploreBtn) {
     step();
   };
 
-  setTimeout(() => type(first), 3000);
+  // start typing shortly after load for a snappier feel
+  const initialDelay = 1000; // ms
+  setTimeout(() => type(first), initialDelay);
   setTimeout(() => {
     del(replace.length, () => {
       type(second, () => exploreBtn.classList.add('show'));
     });
-  }, 18000);
+  }, initialDelay + 15000);
 }
 
 // Subtle scroll cue


### PR DESCRIPTION
## Summary
- Start hero typewriter animation one second after load for a faster feel
- Maintain the follow-up text timing relative to the earlier start

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f9ef6d61c8325bcdbac525d5da596