### PR TITLE
Limit galleries to two columns

### DIFF
--- a/project.html
+++ b/project.html
@@ -13,7 +13,7 @@
         <h1 id="proj-title" class="section-title">Project</h1>
         <video id="proj-video" class="project-video" controls playsinline></video>
         <p id="proj-desc" class="project-desc"></p>
-        <div id="proj-media" class="projects-grid" style="grid-template-columns:repeat(3,1fr)"></div>
+        <div id="proj-media" class="projects-grid"></div>
       </div>
     </section>
   </main>

--- a/style.css
+++ b/style.css
@@ -135,9 +135,9 @@ h1,h2,h3{line-height:1.2}
 .fade-in{opacity:0;animation:fadeInUp .6s forwards}
 
 /* Projects grid */
-.projects-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:16px}
+.projects-grid{display:grid;grid-template-columns:repeat(2,1fr);gap:16px}
 .projects-grid a{display:block;border:1px solid #22303a;border-radius:14px;overflow:hidden;background:#0d1217;position:relative}
-.projects-grid img{width:100%;height:200px;object-fit:cover;display:block}
+.projects-grid img{width:100%;aspect-ratio:4/3;object-fit:cover;display:block}
 .project-video{width:100%;max-height:500px;border-radius:14px;margin-bottom:16px;background:#000}
 .project-desc{margin:16px 0}
 
@@ -159,7 +159,6 @@ h1,h2,h3{line-height:1.2}
   .grid.cards{grid-template-columns:1fr 1fr}
   .grid.featured{grid-template-columns:1fr 1fr}
   .select-grid{grid-template-columns:1fr}
-  .projects-grid{grid-template-columns:1fr 1fr}
   .site-footer .footer-grid{grid-template-columns:1fr}
 }
 @media (max-width: 640px){
@@ -167,4 +166,5 @@ h1,h2,h3{line-height:1.2}
   .menu-btn{display:block}
   .nav{display:none;position:absolute;right:20px;top:58px;background:#0d1217;border:1px solid #23303a;border-radius:12px;padding:10px;width:220px;flex-direction:column}
   .nav.open{display:flex}
+  .projects-grid{grid-template-columns:1fr}
 }


### PR DESCRIPTION
## Summary
- Restrict project galleries to two columns and maintain a 4:3 aspect ratio for images.
- Remove inline three-column layout from project pages and collapse galleries to one column on narrow screens.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f9f6482dc8325a9f3c6d29d639067