### PR TITLE
Add varied typography across site

### DIFF
--- a/404.html
+++ b/404.html
@@ -12,8 +12,6 @@
   <meta property="og:url" content="https://www.nortekroofing.ca/" />
   <link rel="canonical" href="https://www.nortekroofing.ca/" />
   <link rel="icon" href="/favicon.svg" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="style.css" />
   <meta http-equiv="refresh" content="5; url=/index.html">
 </head>

--- a/index.html
+++ b/index.html
@@ -6,8 +6,6 @@
   <title>Nortek Roofing — Commercial & Residential Roofing</title>
   <meta name="description" content="Flat & low‑slope roofing with torch‑on membranes, custom metal, and responsive service across Greater Victoria." />
   <link rel="icon" href="favicon.svg" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="style.css" />
 </head>
 <body class="home">

--- a/style.css
+++ b/style.css
@@ -1,10 +1,12 @@
 
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&family=Poppins:wght@400;600;700&family=Playfair+Display:wght@700&display=swap');
+
 :root{
   --bg:#0f1215; --surface:#151a20; --muted:#8b97a4; --text:#e8edf2; --brand:#1db954;
   --header-h: 64px;
 }
 *{box-sizing:border-box}
-html,body{margin:0;padding:0;background:var(--bg);color:var(--text);font-family:Inter,system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif;line-height:1.6;min-height:100vh}
+html,body{margin:0;padding:0;background:var(--bg);color:var(--text);font-family:'Inter',system-ui,-apple-system,'Segoe UI',Roboto,Arial,sans-serif;line-height:1.6;min-height:100vh}
 body{display:flex;flex-direction:column}
 a{color:var(--text);text-decoration:none}
 img{max-width:100%;height:auto;display:block}
@@ -13,17 +15,17 @@ body.home main{padding-top:0}
 .container{width:100%;margin:0 auto;padding:0 clamp(20px,5vw,60px)}
 .small{font-size:.92rem}.muted{color:var(--muted)}
 .rounded{border-radius:14px}.shadow{box-shadow:0 10px 30px rgba(0,0,0,.35)}
-h1,h2,h3{line-height:1.2}
+h1,h2,h3{line-height:1.2;font-family:'Poppins','Inter',sans-serif}
 
 /* Header */
 .site-header{position:fixed;top:0;left:0;width:100%;z-index:10;background:var(--bg);border-bottom:1px solid #1f2730}
 .header-inner{display:flex;align-items:center;justify-content:space-between;padding:14px 0}
-.brand{display:flex;gap:10px;align-items:center;font-weight:700}
+.brand{display:flex;gap:10px;align-items:center;font-weight:700;font-family:'Poppins','Inter',sans-serif}
 .logo{width:90px;height:auto;border-radius:6px}
-.nav{display:flex;gap:18px;align-items:center}
+.nav{display:flex;gap:18px;align-items:center;font-family:'Poppins','Inter',sans-serif}
 .nav a{color:var(--text)}
 .menu-btn{display:none}
-.btn{padding:10px 14px;border-radius:12px;border:1px solid #23303a;display:inline-block}
+.btn{padding:10px 14px;border-radius:12px;border:1px solid #23303a;display:inline-block;font-family:'Poppins','Inter',sans-serif}
 .btn.primary{background:var(--brand);color:#0b110d;border-color:transparent;font-weight:700}
 .btn.ghost{background:transparent}
 
@@ -34,7 +36,7 @@ h1,h2,h3{line-height:1.2}
 .hero-video .hero-bg{position:absolute;inset:0;width:100%;height:100%;object-fit:cover;filter:brightness(.6);z-index:0}
 .hero-overlay{position:absolute;inset:0;z-index:1;display:flex;flex-direction:column;align-items:center;justify-content:center;text-align:center;padding:0 20px}
 .hero-overlay > *{width:100%}
-.hero-overlay h1{font-size:clamp(2rem,4vw,3rem);margin:0 0 1rem}
+.hero-overlay h1{font-family:'Playfair Display','Poppins',serif;font-size:clamp(2rem,4vw,3rem);margin:0 0 1rem}
 .hero-overlay h1::after{
   content:"";
   display:inline-block;


### PR DESCRIPTION
## Summary
- Import Poppins and Playfair Display fonts
- Apply Poppins to headings, navigation and buttons for a cohesive style
- Use Playfair Display for home hero headline and remove redundant font links

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689fa577d6908325ac6dc92587a83409