### PR TITLE
Add enterprise homepage sections and interactions

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,15 @@
   <meta name="description" content="Flat & low‑slope roofing with torch‑on membranes, custom metal, and responsive service across Greater Victoria." />
   <link rel="icon" href="favicon.svg" />
   <link rel="stylesheet" href="style.css" />
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "RoofingContractor",
+    "name": "Nortek Roofing",
+    "url": "https://nortek-roofing.example.com",
+    "areaServed": ["Vancouver BC", "Victoria BC", "Nanaimo BC", "Kelowna BC", "Kamloops BC"]
+  }
+  </script>
 </head>
 <body class="home">
 
@@ -31,33 +40,128 @@
       </div>
     </section>
 
-    <section class="section">
+    <!-- Impact Statement + Stats -->
+    <section class="section impact" aria-labelledby="impact-title">
       <div class="container">
-        <h2 class="section-title">Featured Projects</h2>
-        <div class="grid featured">
-          <a class="feature-card" href="projects.html">
-            <img src="images/proj-1.jpg" alt="Retail rooftop" loading="lazy">
-            <div class="feature-meta">
-              <h3>Boulderhouse Climbing</h3>
+        <h2 id="impact-title">Building &amp; Protecting Large‑Scale Roofs Across the West Coast</h2>
+        <div class="stats-grid">
+          <div class="stat reveal"><span class="stat-number">25+</span><p class="stat-label small">Years Delivering Complex Projects</p></div>
+          <div class="stat reveal"><span class="stat-number">5M+</span><p class="stat-label small">sq ft Installed</p></div>
+          <div class="stat reveal"><span class="stat-number">180k</span><p class="stat-label small">Largest Single Project (sq ft)</p></div>
+          <div class="stat reveal"><span class="stat-number">Licensed</span><p class="stat-label small">Insured • COR‑Aligned Safety</p></div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Signature Projects Showcase -->
+    <section class="section projects" aria-labelledby="projects-title">
+      <div class="container">
+        <h2 id="projects-title">Signature Projects</h2>
+        <div class="projects-showcase">
+          <a href="images/proj-1.jpg" class="project-tile reveal" data-lightbox="images/proj-1.jpg">
+            <img src="images/proj-1.jpg" alt="Distribution center roof" loading="lazy" decoding="async">
+            <div class="project-meta">
+              <h3>Distribution Center</h3>
+              <p class="small">Industrial</p>
             </div>
           </a>
-          <a class="feature-card" href="projects.html">
-            <img src="images/proj-2.jpg" alt="Strata roof" loading="lazy">
-            <div class="feature-meta">
-              <h3>Hull's Corner Business Park</h3>
+          <a href="images/proj-2.jpg" class="project-tile reveal" data-lightbox="images/proj-2.jpg">
+            <img src="images/proj-2.jpg" alt="Strata complex roof" loading="lazy" decoding="async">
+            <div class="project-meta">
+              <h3>Strata Complex</h3>
+              <p class="small">Multi‑Unit</p>
             </div>
           </a>
-          <a class="feature-card" href="projects.html">
-            <img src="images/proj-3.jpg" alt="Industrial building" loading="lazy">
-            <div class="feature-meta">
-              <h3>Meaford Avenue Apartments</h3>
+          <a href="images/proj-3.jpg" class="project-tile reveal" data-lightbox="images/proj-3.jpg">
+            <img src="images/proj-3.jpg" alt="Manufacturing plant roof" loading="lazy" decoding="async">
+            <div class="project-meta">
+              <h3>Manufacturing Plant</h3>
+              <p class="small">Industrial</p>
+            </div>
+          </a>
+          <a href="images/proj-4.jpg" class="project-tile reveal" data-lightbox="images/proj-4.jpg">
+            <img src="images/proj-4.jpg" alt="Retail center roof" loading="lazy" decoding="async">
+            <div class="project-meta">
+              <h3>Retail Center</h3>
+              <p class="small">Commercial</p>
+            </div>
+          </a>
+          <a href="images/proj-5.jpg" class="project-tile reveal" data-lightbox="images/proj-5.jpg">
+            <img src="images/proj-5.jpg" alt="Warehouse roofing" loading="lazy" decoding="async">
+            <div class="project-meta">
+              <h3>Logistics Warehouse</h3>
+              <p class="small">Logistics</p>
+            </div>
+          </a>
+          <a href="images/proj-6.jpg" class="project-tile reveal" data-lightbox="images/proj-6.jpg">
+            <img src="images/proj-6.jpg" alt="School roof" loading="lazy" decoding="async">
+            <div class="project-meta">
+              <h3>Education Campus</h3>
+              <p class="small">Institutional</p>
             </div>
           </a>
         </div>
       </div>
     </section>
+
+    <!-- Why Nortek Pillars -->
+    <section class="section pillars" aria-labelledby="pillars-title">
+      <div class="container">
+        <h2 id="pillars-title">Why Nortek</h2>
+        <div class="pillars-grid">
+          <div class="pillar-card reveal"><h3>Safety &amp; Compliance at Scale</h3></div>
+          <div class="pillar-card reveal"><h3>On‑Time, On‑Budget Delivery</h3></div>
+          <div class="pillar-card reveal"><h3>Complex Detailing &amp; QA</h3></div>
+          <div class="pillar-card reveal"><h3>Coordination with GCs &amp; Consultants</h3></div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Process Timeline -->
+    <section class="section process" aria-labelledby="process-title">
+      <div class="container">
+        <h2 id="process-title">Process</h2>
+        <ol class="process-timeline">
+          <li class="reveal"><h3>Assessment &amp; Scope</h3></li>
+          <li class="reveal"><h3>Planning &amp; Safety</h3></li>
+          <li class="reveal"><h3>Execution &amp; QA</h3></li>
+          <li class="reveal"><h3>Turnover &amp; Documentation</h3></li>
+          <li class="reveal"><h3>Maintenance Programs</h3></li>
+        </ol>
+      </div>
+    </section>
+
+    <!-- CTA Band -->
+    <section class="section cta-band" aria-labelledby="cta-title">
+      <div class="container">
+        <h2 id="cta-title">Ready to Discuss a Project?</h2>
+        <p class="muted">From retrofits to new builds, our team handles every square foot.</p>
+        <div class="cta-row">
+          <a class="btn primary" href="contact.html">Discuss a Project</a>
+          <a class="btn glass" href="projects.html">View Projects</a>
+        </div>
+      </div>
+    </section>
+
+    <!-- Service Area -->
+    <section class="section" aria-labelledby="service-area-title">
+      <div class="container">
+        <h2 id="service-area-title">Service Area</h2>
+        <div class="service-area">
+          <img src="images/proj-7.jpg" alt="Map of service coverage" loading="lazy" decoding="async">
+          <ul>
+            <li>Vancouver</li>
+            <li>Victoria</li>
+            <li>Nanaimo</li>
+            <li>Kelowna</li>
+            <li>Kamloops</li>
+          </ul>
+        </div>
+      </div>
+    </section>
   </main>
 
+  <div class="lightbox" id="lightbox"><img id="lightbox-img" alt=""></div>
   <div id="site-footer"></div>
 
   <script src="includes.js"></script>

--- a/script.js
+++ b/script.js
@@ -73,3 +73,38 @@ const cue = document.querySelector('.glass-cue');
 if (cue) {
   setTimeout(() => cue.classList.add('show'), 5000);
 }
+
+// Reveal on scroll & lightbox
+document.addEventListener('DOMContentLoaded', () => {
+  const prefersReduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  if (!prefersReduced && 'IntersectionObserver' in window) {
+    const revealEls = document.querySelectorAll('.reveal');
+    const io = new IntersectionObserver((entries, obs) => {
+      entries.forEach(entry => {
+        if (entry.isIntersecting) {
+          entry.target.classList.add('in');
+          obs.unobserve(entry.target);
+        }
+      });
+    }, { threshold: 0.15 });
+    revealEls.forEach((el, i) => {
+      el.style.transitionDelay = `${i * 60}ms`;
+      io.observe(el);
+    });
+  } else {
+    document.querySelectorAll('.reveal').forEach(el => el.classList.add('in'));
+  }
+
+  const lb = document.getElementById('lightbox');
+  if (lb) {
+    const lbImg = document.getElementById('lightbox-img');
+    document.addEventListener('click', e => {
+      const a = e.target.closest('[data-lightbox]');
+      if (!a) return;
+      e.preventDefault();
+      lbImg.src = a.dataset.lightbox || a.href;
+      lb.classList.add('open');
+    });
+    lb.addEventListener('click', () => lb.classList.remove('open'));
+  }
+});

--- a/style.css
+++ b/style.css
@@ -181,3 +181,30 @@ h1,h2,h3{line-height:1.2;font-family:'Poppins','Inter',sans-serif}
   .nav.open{display:flex}
   .projects-grid{grid-template-columns:1fr}
 }
+
+/* HOMEPAGE SECTIONS */
+.reveal{opacity:0;transform:translateY(16px);transition:opacity .35s ease,transform .35s ease}
+.reveal.in{opacity:1;transform:none}
+@media (prefers-reduced-motion:reduce){.reveal{opacity:1!important;transform:none!important;transition:none!important}}
+.stats-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(160px,1fr));gap:24px;text-align:center;margin-top:24px}
+.stat-number{display:block;font-size:clamp(1.8rem,4vw,2.6rem);font-weight:700;margin-bottom:6px}
+.projects-showcase{display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:18px}
+.project-tile{position:relative;display:block;border:1px solid #222c36;border-radius:16px;overflow:hidden;background:var(--surface);box-shadow:0 10px 30px rgba(0,0,0,.35);transition:transform .35s ease,filter .35s ease}
+.project-tile img{width:100%;aspect-ratio:4/3;object-fit:cover}
+.project-tile .project-meta{position:absolute;left:0;right:0;bottom:0;padding:12px;background:linear-gradient(180deg,rgba(0,0,0,0),rgba(0,0,0,.6))}
+.project-tile:hover,.project-tile:focus{transform:translateY(-2px);filter:brightness(1.05);outline:none}
+.pillars-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:18px;margin-top:24px}
+.pillar-card{background:var(--surface);border:1px solid #222c36;border-radius:16px;padding:24px}
+.process-timeline{display:flex;list-style:none;gap:18px;margin:24px 0 0;padding:0}
+.process-timeline li{flex:1;background:var(--surface);border:1px solid #222c36;border-radius:16px;padding:20px;position:relative}
+.process-timeline li:not(:last-child)::after{content:"";position:absolute;top:50%;right:-9px;width:18px;height:2px;background:#222c36;transform:translateY(-50%)}
+@media (max-width:980px){.process-timeline{flex-direction:column}.process-timeline li:not(:last-child)::after{top:auto;bottom:-9px;left:50%;right:auto;width:2px;height:18px;transform:translateX(-50%)}}
+.cta-band{text-align:center}
+.cta-band p{margin:12px 0 24px}
+.cta-band .btn{margin:4px 8px}
+.service-area{margin-top:24px;display:grid;grid-template-columns:2fr 1fr;gap:24px;align-items:center}
+.service-area img{width:100%;border-radius:16px;border:1px solid #222c36;aspect-ratio:4/3;object-fit:cover}
+.service-area ul{list-style:none;padding:0;margin:0}
+.service-area li{margin:6px 0}
+@media (max-width:980px){.service-area{grid-template-columns:1fr}}
+.full-bleed{width:100vw;margin-left:50%;transform:translateX(-50%)}


### PR DESCRIPTION
## Summary
- Introduce impact statement, project showcase, value pillars, process timeline, CTA band, and service area map to the homepage.
- Style new homepage sections and reveal animations while preserving the existing dark palette.
- Add intersection observer-driven reveals and a lightweight lightbox for project tiles plus JSON-LD for roofing contractor metadata.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689fac6225648325a6fd1c1a80c59ade