### PR TITLE
Add placeholder image to About page layout

### DIFF
--- a/about.html
+++ b/about.html
@@ -6,10 +6,15 @@
   <main>
     <section class="section">
       <div class="container">
-        <h1 class="section-title">About Nortek Roofing</h1>
-        <p>Established in 2011, Nortek Roofing draws on the decades of experience of founder Alex Martinez, who began his roofing career in 1997. From these roots, the company has grown into a trusted provider of commercial and industrial roofing solutions, delivering projects with technical precision and lasting performance.</p>
-        <p>Our team is composed of skilled professionals who bring specialized knowledge to every project, ensuring compliance with the highest industry and manufacturer standards. We prioritize continual training and development, equipping our workforce to deliver complex roofing systems with consistency and confidence.</p>
-        <p>Nortek Roofing is defined by its focus on long-service roofing assemblies and large-scale applications. We combine proven installation methods with a culture of professionalism, positioning us as a dependable partner for contractors, builders, and property owners seeking durable and technically sound roofing solutions.</p>
+        <div class="about-split">
+          <div>
+            <h1 class="section-title">About Nortek Roofing</h1>
+            <p>Established in 2011, Nortek Roofing draws on the decades of experience of founder Alex Martinez, who began his roofing career in 1997. From these roots, the company has grown into a trusted provider of commercial and industrial roofing solutions, delivering projects with technical precision and lasting performance.</p>
+            <p>Our team is composed of skilled professionals who bring specialized knowledge to every project, ensuring compliance with the highest industry and manufacturer standards. We prioritize continual training and development, equipping our workforce to deliver complex roofing systems with consistency and confidence.</p>
+            <p>Nortek Roofing is defined by its focus on long-service roofing assemblies and large-scale applications. We combine proven installation methods with a culture of professionalism, positioning us as a dependable partner for contractors, builders, and property owners seeking durable and technically sound roofing solutions.</p>
+          </div>
+          <img src="https://via.placeholder.com/600x400" alt="Roofing team placeholder image" class="rounded"/>
+        </div>
       </div>
     </section>
     <section class="section alt">


### PR DESCRIPTION
## Summary
- Structure About page introduction with two-column layout
- Include placeholder image beside introductory text

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689fafd61f4c83259e407ccc07f629c8