### PR TITLE
feat: add neon glow to stats

### DIFF
--- a/style.css
+++ b/style.css
@@ -185,7 +185,10 @@ h1,h2,h3{line-height:1.2}
 .reveal.in{opacity:1;transform:none}
 @media (prefers-reduced-motion:reduce){.reveal{opacity:1!important;transform:none!important;transition:none!important}}
 .stats-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(160px,1fr));gap:24px;text-align:center;margin-top:24px}
-.stat-number{display:block;font-size:clamp(1.8rem,4vw,2.6rem);font-weight:700;margin-bottom:6px}
+.stat{padding:20px;border-radius:12px;border:1px solid var(--brand);background:rgba(0,0,0,.4);box-shadow:0 0 10px var(--brand),0 0 20px rgba(29,185,84,.6);animation:neonPulse 2s ease-in-out infinite alternate}
+.stat-number{display:block;font-size:clamp(1.8rem,4vw,2.6rem);font-weight:700;margin-bottom:6px;color:var(--brand);text-shadow:0 0 8px var(--brand),0 0 16px var(--brand)}
+.stat-label{text-shadow:0 0 4px rgba(29,185,84,.6)}
+@keyframes neonPulse{from{box-shadow:0 0 6px var(--brand),0 0 12px rgba(29,185,84,.6)}to{box-shadow:0 0 12px var(--brand),0 0 24px rgba(29,185,84,.8)}}
 .projects-showcase{display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:18px}
 .project-tile{position:relative;display:block;border:1px solid #222c36;border-radius:16px;overflow:hidden;background:var(--surface);box-shadow:0 10px 30px rgba(0,0,0,.35);transition:transform .35s ease,filter .35s ease}
 .project-tile img{width:100%;aspect-ratio:4/3;object-fit:cover}


### PR DESCRIPTION
## Summary
- add neon sign-style glow to homepage stats

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689fb4208dc483258b5c1fc346241ea3