### PR TITLE
Add gradient page banners to site headers

### DIFF
--- a/404.html
+++ b/404.html
@@ -35,9 +35,13 @@
     </div>
   </header>
 
-<main class="section">
+<section class="page-banner">
   <div class="container">
     <h1>Page not found</h1>
+  </div>
+</section>
+<main class="section">
+  <div class="container">
     <p class="muted">This page doesn’t exist. You’ll be redirected to the homepage in a few seconds.</p>
     <p><a class="btn primary" href="/index.html">Go home now</a></p>
   </div>

--- a/about.html
+++ b/about.html
@@ -4,11 +4,15 @@
 <body>
   <div id="site-header"></div>
   <main>
+    <section class="page-banner">
+      <div class="container">
+        <h1>About Nortek Roofing</h1>
+      </div>
+    </section>
     <section class="section">
       <div class="container">
         <div class="about-split">
           <div>
-            <h1 class="section-title">About Nortek Roofing</h1>
             <p>Established in 2011, Nortek Roofing draws on the decades of experience of founder Alex Martinez, who began his roofing career in 1997. From these roots, the company has grown into a trusted provider of commercial and industrial roofing solutions, delivering projects with technical precision and lasting performance.</p>
             <p>Our team is composed of skilled professionals who bring specialized knowledge to every project, ensuring compliance with the highest industry and manufacturer standards. We prioritize continual training and development, equipping our workforce to deliver complex roofing systems with consistency and confidence.</p>
             <p>Nortek Roofing is defined by its focus on long-service roofing assemblies and large-scale applications. We combine proven installation methods with a culture of professionalism, positioning us as a dependable partner for contractors, builders, and property owners seeking durable and technically sound roofing solutions.</p>

--- a/careers.html
+++ b/careers.html
@@ -4,9 +4,13 @@
 <body>
   <div id="site-header"></div>
   <main>
+    <section class="page-banner">
+      <div class="container">
+        <h1>Careers</h1>
+      </div>
+    </section>
     <section class="section">
       <div class="container">
-        <h1 class="section-title">Careers</h1>
         <p>Join our growing team. Browse our current openings below.</p>
         <div class="grid cards">
           <div class="card">

--- a/contact.html
+++ b/contact.html
@@ -4,9 +4,13 @@
 <body>
   <div id="site-header"></div>
   <main>
+    <section class="page-banner">
+      <div class="container">
+        <h1>Request a Quote</h1>
+      </div>
+    </section>
     <section class="section">
       <div class="container">
-        <h1 class="section-title">Request a Quote</h1>
         <p class="muted">Email us at <a id="contact-email" href="#">email</a> or call <a id="contact-phone" href="#">phone</a>.</p>
         <script>fetch('data/site-config.json').then(r=>r.json()).then(c=>{ 
           const e=document.getElementById('contact-email'); e.textContent=c.email; e.href='mailto:'+c.email;

--- a/privacy.html
+++ b/privacy.html
@@ -4,9 +4,13 @@
 <body>
   <div id="site-header"></div>
   <main>
+    <section class="page-banner">
+      <div class="container">
+        <h1>Privacy</h1>
+      </div>
+    </section>
     <section class="section">
       <div class="container">
-        <h1 class="section-title">Privacy</h1>
         <p class="muted">We use only essential information you send to respond to your inquiry. We do not sell your data.</p>
         <p class="small muted">© 2025 Nortek Roofing</p>
       </div>

--- a/project.html
+++ b/project.html
@@ -8,9 +8,13 @@
 <body>
   <div id="site-header"></div>
   <main>
+    <section class="page-banner">
+      <div class="container">
+        <h1 id="proj-title">Project</h1>
+      </div>
+    </section>
     <section class="section">
       <div class="container">
-        <h1 id="proj-title" class="section-title">Project</h1>
         <video id="proj-video" class="project-video" controls playsinline></video>
         <p id="proj-desc" class="project-desc"></p>
         <div id="proj-media" class="projects-grid"></div>

--- a/projects-commercial.html
+++ b/projects-commercial.html
@@ -8,9 +8,13 @@
 <body>
   <div id="site-header"></div>
   <main>
+    <section class="page-banner">
+      <div class="container">
+        <h1>Commercial Projects</h1>
+      </div>
+    </section>
     <section class="section">
       <div class="container">
-        <h1 class="section-title">Commercial Projects</h1>
         <div id="projects" class="projects-grid"></div>
         <div style="text-align:center;margin-top:24px;">
           <a class="btn" href="projects-residential.html">View Residential Projects</a>

--- a/projects-residential.html
+++ b/projects-residential.html
@@ -8,9 +8,13 @@
 <body>
   <div id="site-header"></div>
   <main>
+    <section class="page-banner">
+      <div class="container">
+        <h1>Residential Projects</h1>
+      </div>
+    </section>
     <section class="section">
       <div class="container">
-        <h1 class="section-title">Residential Projects</h1>
         <div id="projects" class="projects-grid"></div>
         <div style="text-align:center;margin-top:24px;">
           <a class="btn" href="projects-commercial.html">View Commercial Projects</a>

--- a/projects.html
+++ b/projects.html
@@ -8,9 +8,13 @@
 <body>
   <div id="site-header"></div>
   <main>
+    <section class="page-banner">
+      <div class="container">
+        <h1>Projects</h1>
+      </div>
+    </section>
     <section class="section">
       <div class="container">
-        <h1 class="section-title">Projects</h1>
         <div id="projects"></div>
       </div>
     </section>

--- a/services-test.html
+++ b/services-test.html
@@ -19,9 +19,13 @@
   </style>
 </head>
 <body>
+  <section class="page-banner">
+    <div class="container">
+      <h1>Test: Big Select Buttons</h1>
+    </div>
+  </section>
   <main class="section services-landing">
     <div class="container">
-      <h1 class="section-title">Test: Big Select Buttons</h1>
       <div class="select-grid">
         <a class="select-card" href="#"><div class="select-card__shade"></div><div class="select-card__glass"><h2>Commercial</h2><p>Spec-driven builds</p><span class="select-card__tag">Submittals • Scheduling</span></div></a>
         <a class="select-card" href="#"><div class="select-card__shade"></div><div class="select-card__glass"><h2>Residential</h2><p>Clean, respectful crews</p><span class="select-card__tag">Repairs • Re-roofs</span></div></a>

--- a/services.html
+++ b/services.html
@@ -8,9 +8,13 @@
 <body>
   <div id="site-header"></div>
   <main>
+    <section class="page-banner">
+      <div class="container">
+        <h1>How can we help?</h1>
+      </div>
+    </section>
     <section class="section services-landing">
       <div class="container">
-        <h1 class="section-title">How can we help?</h1>
         <div class="select-grid">
           <a class="select-card" href="services-commercial.html" style="--card-bg:url('images/services-commercial.jpg')">
             <div class="select-card__shade"></div>

--- a/style.css
+++ b/style.css
@@ -118,6 +118,10 @@ h1,h2,h3{line-height:1.2}
 .section{padding:64px 0;border-bottom:1px solid #1f2730}
 .section.alt{background:linear-gradient(180deg, rgba(255,255,255,0.02), transparent)}
 .section-title{font-size:1.9rem;margin:0 0 22px}
+.page-banner{padding:80px 0;text-align:center;position:relative;background:linear-gradient(135deg,rgba(29,185,84,.2),rgba(29,185,84,.05));border-bottom:1px solid #1f2730}
+.page-banner::before{content:"";position:absolute;inset:0;background:radial-gradient(circle at top left,rgba(29,185,84,.25),transparent 70%);pointer-events:none}
+.page-banner::after{content:"";position:absolute;left:50%;bottom:0;width:120px;height:3px;background:var(--brand);transform:translateX(-50%);border-radius:2px 2px 0 0}
+.page-banner h1{margin:0;font-size:clamp(2rem,4vw,3rem)}
 .grid.cards{display:grid;grid-template-columns:repeat(4,1fr);gap:18px}
 .card{background:var(--surface);border:1px solid #222c36;border-radius:16px;padding:18px}
 .grid.featured{display:grid;grid-template-columns:repeat(3,1fr);gap:18px}


### PR DESCRIPTION
## Summary
- Introduce reusable `page-banner` class with gradient background and accent stripe
- Convert top headings on content pages to use new banner markup

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689fb4c7401c8325b658de37d5f4308d