### PR TITLE
Restore Services navigation and project links

### DIFF
--- a/flat-roofing.html
+++ b/flat-roofing.html
@@ -32,6 +32,9 @@
           <a class="btn primary" href="contact.html">Request a Quote</a>
         </section>
         <p class="small">These systems are the industry standard for large-scale commercial and industrial projects, while also offering reliable solutions for residential low-slope roofs.</p>
+        <div style="text-align:center;margin-top:24px;">
+          <a class="btn" href="projects-commercial.html">View Commercial Projects</a>
+        </div>
       </div>
     </section>
   </main>

--- a/header.html
+++ b/header.html
@@ -6,13 +6,7 @@
     </a>
     <nav class="nav" id="nav">
       <a href="projects.html">Projects</a>
-      <div class="dropdown">
-        <button class="dropbtn" id="servicesToggle">Services</button>
-        <div class="dropdown-menu">
-          <a href="flat-roofing.html">Flat Roofing</a>
-          <a href="metal-roofing.html">Metal Roofing</a>
-        </div>
-      </div>
+      <a href="services.html">Services</a>
       <a href="about.html">About</a>
       <a href="contact.html" class="btn primary">Contact</a>
     </nav>

--- a/metal-roofing.html
+++ b/metal-roofing.html
@@ -31,6 +31,9 @@
           <a class="btn primary" href="contact.html">Request a Quote</a>
         </section>
         <p class="small">A premium choice for projects requiring architectural appeal, superior protection, and decades of dependable service. This system is primarily for commercial and industrial projects but can also be applied to residential custom homes.</p>
+        <div style="text-align:center;margin-top:24px;">
+          <a class="btn" href="projects-residential.html">View Residential Projects</a>
+        </div>
       </div>
     </section>
   </main>


### PR DESCRIPTION
## Summary
- revert header to single Services link leading to services overview
- add buttons on flat and metal roofing pages to view related projects

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689fb8dede18832584242f982ec32100