### PR TITLE
Delay Explore Services button after hero text animation

### DIFF
--- a/script.js
+++ b/script.js
@@ -21,6 +21,7 @@ if (heroText && exploreBtn) {
   const min = 75;
   const max = 175;
   const delay = () => Math.random() * (max - min) + min;
+  const btnDelay = 1500;
   heroText.textContent = '';
 
   const type = (text, cb) => {
@@ -50,7 +51,7 @@ if (heroText && exploreBtn) {
       type(first, () => {
         setTimeout(() => {
           del(replace.length, () => {
-            type(second, () => setTimeout(() => exploreBtn.classList.add('show'), 100));
+            type(second, () => setTimeout(() => exploreBtn.classList.add('show'), btnDelay));
           });
         }, 1000);
       });


### PR DESCRIPTION
## Summary
- Pause Explore Services button reveal for 1.5s to spotlight hero text typewriter animation
- Make button delay configurable via `btnDelay`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689fba1357fc8325bc4cb0e74e926c31