### PR TITLE
feat: add hero nav glide

### DIFF
--- a/includes.js
+++ b/includes.js
@@ -49,5 +49,18 @@ async function applyConfig(){
         }
       });
     }
+
+    // Hero nav glide effect
+    const headerEl = document.querySelector('.site-header');
+    const hero = document.querySelector('.hero-video');
+    if (headerEl && hero){
+      const update = () => {
+        const offset = Math.max(hero.getBoundingClientRect().bottom - headerEl.offsetHeight, 0);
+        headerEl.style.transform = `translateY(${offset}px)`;
+      };
+      update();
+      window.addEventListener('scroll', update, { passive: true });
+      window.addEventListener('resize', update);
+    }
   });
 })();

--- a/style.css
+++ b/style.css
@@ -16,7 +16,7 @@ body.home main{padding-top:0}
 h1,h2,h3{line-height:1.2}
 
 /* Header */
-.site-header{position:fixed;top:0;left:0;right:0;z-index:10;background:var(--bg);border-bottom:1px solid #1f2730}
+.site-header{position:fixed;top:0;left:0;right:0;z-index:10;background:var(--bg);border-bottom:1px solid #1f2730;transform:translateY(0);will-change:transform}
 .header-inner{display:flex;align-items:center;justify-content:space-between;padding:14px 0}
 .brand{display:flex;gap:10px;align-items:center;font-weight:700}
 .logo{width:90px;height:auto;border-radius:6px}


### PR DESCRIPTION
## Summary
- Let hero navigation glide from bottom to top on scroll
- Prepare header styles for transform-based positioning

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: sh: 1: next: not found)


------
https://chatgpt.com/codex/tasks/task_e_68a969e0cb848325a86d4b2cea469677