### PR TITLE
Add lint and test scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ logs
 studio/node_modules
 studio/.sanity
 studio/dist
+
+# TypeScript
+tsconfig.tsbuildinfo

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint",
+    "lint": "tsc --noEmit",
+    "test": "npm run lint",
     "studio": "npm run dev --prefix studio",
     "studio:build": "npm run build --prefix studio",
     "studio:serve": "npm run start --prefix studio"


### PR DESCRIPTION
## Summary
- use TypeScript compiler as lint step
- add test script to run the lint step
- ignore TypeScript build info artifacts

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a96a9eac088325a20ace8e10317585