### PR TITLE
feat: replace hero overlay text

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,18 +29,24 @@
         <source src="hero.mp4" type="video/mp4">
       </video>
         <div class="hero-overlay">
-          <h1 id="heroText">made for the island.</h1>
+          <div class="hero-copy">
+            <p>BUILT FOR THE ISLAND.</p>
+            <p>ENGINEERED FOR RESILIENCE.</p>
+            <p>INSTALLED WITH PRECISION.</p>
+            <p>DESIGNED TO STAND THE TEST OF TIME.</p>
+            <p><em>NORTEK.</em></p>
+          </div>
           <div class="cta-row">
             <a id="exploreBtn" class="btn glass" href="services.html">Explore Services</a>
           </div>
-        <div class="cta-row">
-          <div class="glass-cue" aria-label="Scroll to content"
-            onclick="document.querySelector('main .section')?.scrollIntoView({behavior:'smooth'})">
-            <span class="glass-cue__arrow" aria-hidden="true"></span>
+          <div class="cta-row">
+            <div class="glass-cue" aria-label="Scroll to content"
+              onclick="document.querySelector('main .section')?.scrollIntoView({behavior:'smooth'})">
+              <span class="glass-cue__arrow" aria-hidden="true"></span>
+            </div>
           </div>
         </div>
-      </div>
-    </section>
+      </section>
 
     <!-- Impact Statement + Stats -->
     <section class="section impact" aria-labelledby="impact-title">

--- a/script.js
+++ b/script.js
@@ -11,63 +11,7 @@ if (v){
   window.addEventListener('scroll', kick, { passive:true });
 }
 
-// Hero text typewriter effect
-const heroText = document.getElementById('heroText');
-const exploreBtn = document.getElementById('exploreBtn');
-if (heroText && exploreBtn) {
-  const first = 'made for the island.';
-  const replace = 'the island.';
-  const second = 'you.';
-  const min = 75;
-  const max = 175;
-  const delay = () => Math.random() * (max - min) + min;
-  const btnDelay = 1500;
-  heroText.textContent = '';
-
-  const type = (text, cb) => {
-    let i = 0;
-    const step = () => {
-      if (i < text.length) {
-        heroText.textContent += text[i++];
-        setTimeout(step, delay());
-      } else if (cb) cb();
-    };
-    step();
-  };
-
-  const del = (count, cb) => {
-    const step = () => {
-      if (count > 0) {
-        heroText.textContent = heroText.textContent.slice(0, -1);
-        count--;
-        setTimeout(step, delay());
-      } else if (cb) cb();
-    };
-    step();
-  };
-
-  const run = () => {
-    setTimeout(() => {
-      type(first, () => {
-        setTimeout(() => {
-          del(replace.length, () => {
-            type(second, () => setTimeout(() => exploreBtn.classList.add('show'), btnDelay));
-          });
-        }, 1000);
-      });
-    }, 500);
-  };
-
-  if (v) {
-    if (!v.paused && v.currentTime > 0) {
-      run();
-    } else {
-      v.addEventListener('playing', run, { once: true });
-    }
-  } else {
-    run();
-  }
-}
+// (Typewriter effect removed; hero text is now static)
 
 // Subtle scroll cue
 const cue = document.querySelector('.glass-cue');

--- a/style.css
+++ b/style.css
@@ -38,24 +38,12 @@ h1,h2,h3{line-height:1.2}
 @supports (height:100dvh){ .hero-video{ height:100dvh; } }
 @supports not (height:100svh){ .hero-video{ height:100vh; } }
 .hero-video .hero-bg{position:absolute;inset:0;width:100%;height:100%;object-fit:cover;filter:brightness(.6);z-index:0}
-.hero-overlay{position:absolute;inset:0;z-index:1;display:flex;flex-direction:column;align-items:center;justify-content:center;text-align:center;padding:0 20px}
+.hero-overlay{position:absolute;inset:0;z-index:1;display:flex;flex-direction:column;align-items:flex-start;justify-content:flex-end;text-align:left;padding:0 20px 10vh}
 .hero-overlay > *{width:100%}
-.hero-overlay h1{font-size:clamp(2rem,4vw,3rem);margin:0 0 1rem}
-.hero-overlay h1::after{
-  content:"";
-  display:inline-block;
-  width:2px;
-  height:1em;
-  margin-left:4px;
-  background:currentColor;
-  animation:blink 1s steps(2,start) infinite;
-  vertical-align:bottom;
-}
-@keyframes blink{50%{opacity:0}}
-.hero-overlay p{width:100%;margin:0 0 1.0rem}
-.cta-row{display:flex;gap:12px;flex-wrap:wrap;justify-content:center;margin:10px 0 0}
-#exploreBtn{opacity:0;pointer-events:none;transform:translateY(10px) scale(.95);transition:opacity 1.2s ease,transform 1.2s ease}
-#exploreBtn.show{opacity:1;pointer-events:auto;transform:translateY(0) scale(1)}
+.hero-copy{font-family:'Garamond',serif;font-size:clamp(2.5rem,6vw,4rem);line-height:1.1;font-weight:400}
+.hero-copy p{margin:0}
+.cta-row{display:flex;gap:12px;flex-wrap:wrap;justify-content:flex-start;margin:20px 0 0}
+#exploreBtn{opacity:1;pointer-events:auto;transform:none;transition:opacity 1.2s ease,transform 1.2s ease}
 
 /* Opaque Glass Button */
 .btn.glass {


### PR DESCRIPTION
## Summary
- Replace hero typewriter text with static Garamond hero copy
- Align hero overlay text to the lower-left and reveal CTA immediately
- Remove typewriter JavaScript for static overlay

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a976215da483258c26921a6ae33c9b