### PR TITLE
Refine hero overlay and remove services CTA

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,9 +37,6 @@
             <p><em>NORTEK.</em></p>
           </div>
           <div class="cta-row">
-            <a id="exploreBtn" class="btn glass" href="services.html">Explore Services</a>
-          </div>
-          <div class="cta-row">
             <div class="glass-cue" aria-label="Scroll to content"
               onclick="document.querySelector('main .section')?.scrollIntoView({behavior:'smooth'})">
               <span class="glass-cue__arrow" aria-hidden="true"></span>

--- a/style.css
+++ b/style.css
@@ -38,12 +38,20 @@ h1,h2,h3{line-height:1.2}
 @supports (height:100dvh){ .hero-video{ height:100dvh; } }
 @supports not (height:100svh){ .hero-video{ height:100vh; } }
 .hero-video .hero-bg{position:absolute;inset:0;width:100%;height:100%;object-fit:cover;filter:brightness(.6);z-index:0}
-.hero-overlay{position:absolute;inset:0;z-index:1;display:flex;flex-direction:column;align-items:flex-start;justify-content:flex-end;text-align:left;padding:0 20px 10vh}
-.hero-overlay > *{width:100%}
-.hero-copy{font-family:'Garamond',serif;font-size:clamp(2.5rem,6vw,4rem);line-height:1.1;font-weight:400}
+.hero-overlay{position:absolute;inset:0;z-index:1;display:flex;flex-direction:column;align-items:flex-start;justify-content:flex-end;text-align:left;padding:0 20px 10vh;overflow:hidden}
+.hero-overlay > *{width:100%;position:relative;z-index:1}
+.hero-overlay::before{content:"";position:absolute;inset:0;background:
+    linear-gradient(to top,rgba(0,0,0,0.6),rgba(0,0,0,0.2) 60%,rgba(0,0,0,0)),
+    url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='200' height='200'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.8' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
+  background-size:cover,200px 200px;
+  background-repeat:no-repeat,repeat;
+  background-blend-mode:overlay;
+  opacity:.35;
+  pointer-events:none;
+  z-index:0}
+.hero-copy{font-family:'Garamond',serif;font-size:clamp(2.25rem,5.4vw,3.6rem);line-height:1.1;font-weight:400}
 .hero-copy p{margin:0}
 .cta-row{display:flex;gap:12px;flex-wrap:wrap;justify-content:flex-start;margin:20px 0 0}
-#exploreBtn{opacity:1;pointer-events:auto;transform:none;transition:opacity 1.2s ease,transform 1.2s ease}
 
 /* Opaque Glass Button */
 .btn.glass {


### PR DESCRIPTION
## Summary
- reduce hero text size by 10%
- add gradient film grain overlay for improved legibility
- remove Explore Services call-to-action from hero section

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a9780d48508325a0554287b46bb510