### PR TITLE
feat: switch site to light theme

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -3,12 +3,12 @@
 @tailwind utilities;
 
 :root{
-  --bg:#0f1215;
-  --surface:#1a1f24;
-  --text:#e8edf2;
-  --muted:#8b97a4;
+  --bg:#ffffff;
+  --surface:#f5f5f5;
+  --text:#1e293b;
+  --muted:#5f6c80;
   --brand:#1db954;
-  --brand-foreground:#0f1215;
+  --brand-foreground:#ffffff;
   --header-h:64px;
 }
 
@@ -23,12 +23,12 @@ h1,h2,h3,h4,h5,h6{font-family:var(--font-playfair),serif;}
   display:inline-block;
   padding:0.5rem 1.25rem;
   border-radius:9999px;
-  background:rgba(255,255,255,0.08);
+  background:rgba(0,0,0,0.05);
   backdrop-filter:blur(12px);
   -webkit-backdrop-filter:blur(12px);
-  border:1px solid rgba(255,255,255,0.15);
+  border:1px solid rgba(0,0,0,0.1);
   transition:background .3s,border-color .3s;
 }
-.btn:hover{background:rgba(255,255,255,0.16);border-color:rgba(255,255,255,0.25)}
+.btn:hover{background:rgba(0,0,0,0.1);border-color:rgba(0,0,0,0.2)}
 .btn-primary{background:var(--brand);color:var(--brand-foreground);border-color:var(--brand)}
 .btn-primary:hover{background:transparent;color:var(--brand)}

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1,5 +1,5 @@
 
-body { font-family: Arial, sans-serif; margin:0; padding:0; }
-header, footer { background:#333; color:#fff; padding:1rem; text-align:center; }
-nav a { color:#fff; margin:0 0.5rem; text-decoration:none; }
+body { font-family: Arial, sans-serif; margin:0; padding:0; background:#fff; color:#1e293b; }
+header, footer { background:#fff; color:#1e293b; padding:1rem; text-align:center; border-bottom:1px solid #e5e7eb; }
+nav a { color:#1e293b; margin:0 0.5rem; text-decoration:none; }
 .container { max-width: 1200px; margin:0 auto; padding: 1rem; }

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -1,6 +1,6 @@
 export default function Footer(){
   return (
-    <footer className="mt-16 border-t border-white/10">
+    <footer className="mt-16 border-t border-black/10">
       <div className="container py-8 text-sm text-muted">
         © {new Date().getFullYear()} Nortek Roofing · info@nortekexteriors.com · 250-590-7164
       </div>

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -2,13 +2,13 @@ import Link from 'next/link'
 
 export default function Header(){
   return (
-    <header className="sticky top-0 z-50 border-b border-white/10 bg-black/40 backdrop-blur-md">
+    <header className="sticky top-0 z-50 border-b border-black/10 bg-white/80 backdrop-blur-md">
       <div className="container flex h-[var(--header-h)] items-center justify-between">
         <Link href="/" className="font-bold tracking-wide">Nortek</Link>
         <nav className="flex gap-6 text-sm">
-          <Link href="/projects" className="hover:text-white">Projects</Link>
-          <Link href="/services" className="hover:text-white">Services</Link>
-          <Link href="/about" className="hover:text-white">About</Link>
+          <Link href="/projects" className="hover:text-black">Projects</Link>
+          <Link href="/services" className="hover:text-black">Services</Link>
+          <Link href="/about" className="hover:text-black">About</Link>
           <Link href="/contact" className="btn btn-primary">Contact</Link>
         </nav>
       </div>

--- a/style.css
+++ b/style.css
@@ -1,6 +1,6 @@
 
 :root{
-  --bg:#0f1215; --surface:#151a20; --muted:#8b97a4; --text:#e8edf2; --brand:#1db954;
+  --bg:#ffffff; --surface:#f5f5f5; --muted:#5f6c80; --text:#1e293b; --brand:#1db954;
   --header-h: 64px;
 }
 *{box-sizing:border-box}
@@ -16,7 +16,7 @@ body.home main{padding-top:0}
 h1,h2,h3{line-height:1.2}
 
 /* Header */
-.site-header{position:fixed;top:0;left:0;right:0;z-index:10;background:var(--bg);border-bottom:1px solid #1f2730;transform:translateY(0);will-change:transform}
+.site-header{position:fixed;top:0;left:0;right:0;z-index:10;background:var(--bg);border-bottom:1px solid #e5e7eb;transform:translateY(0);will-change:transform}
 .header-inner{display:flex;align-items:center;justify-content:space-between;padding:14px 0}
 .brand{display:flex;gap:10px;align-items:center;font-weight:700}
 .logo{width:90px;height:auto;border-radius:6px}
@@ -25,16 +25,16 @@ h1,h2,h3{line-height:1.2}
 .nav .dropdown{position:relative}
 .nav .dropbtn{background:none;border:none;color:var(--text);font-family:'Poppins','Inter',sans-serif;cursor:pointer;padding:0}
 .nav .dropbtn::after{content:'\25BE';margin-left:4px;font-size:.8em}
-.nav .dropdown-menu{display:none;position:absolute;top:calc(100% + 8px);left:0;background:#0d1217;border:1px solid #23303a;border-radius:12px;padding:10px;flex-direction:column;min-width:160px}
+.nav .dropdown-menu{display:none;position:absolute;top:calc(100% + 8px);left:0;background:#ffffff;border:1px solid #d1d5db;border-radius:12px;padding:10px;flex-direction:column;min-width:160px}
 .nav .dropdown-menu a{padding:6px 8px;white-space:nowrap}
 .nav .dropdown:hover .dropdown-menu{display:flex}
 .menu-btn{display:none}
-.btn{padding:10px 14px;border-radius:12px;border:1px solid #23303a;display:inline-block}
-.btn.primary{background:var(--brand);color:#0b110d;border-color:transparent;font-weight:700}
+.btn{padding:10px 14px;border-radius:12px;border:1px solid #d1d5db;display:inline-block}
+.btn.primary{background:var(--brand);color:#ffffff;border-color:transparent;font-weight:700}
 .btn.ghost{background:transparent}
 
 /* Hero video */
-.hero-video{position:relative;width:100%;height:100svh;overflow:hidden;background:#0d1217;border-bottom:1px solid #1f2730}
+.hero-video{position:relative;width:100%;height:100svh;overflow:hidden;background:#f9fafb;border-bottom:1px solid #e5e7eb}
 @supports (height:100dvh){ .hero-video{ height:100dvh; } }
 @supports not (height:100svh){ .hero-video{ height:100vh; } }
 .hero-video .hero-bg{position:absolute;inset:0;width:100%;height:100%;object-fit:cover;filter:brightness(.6);z-index:0}
@@ -109,17 +109,17 @@ h1,h2,h3{line-height:1.2}
 }
 
 /* Sections */
-.section{padding:64px 0;border-bottom:1px solid #1f2730}
-.section.alt{background:linear-gradient(180deg, rgba(255,255,255,0.02), transparent)}
+.section{padding:64px 0;border-bottom:1px solid #e5e7eb}
+.section.alt{background:linear-gradient(180deg, rgba(0,0,0,0.02), transparent)}
 .section-title{font-size:1.9rem;margin:0 0 22px}
-.page-banner{padding:80px 0;text-align:center;position:relative;background:linear-gradient(135deg,rgba(29,185,84,.2),rgba(29,185,84,.05));border-bottom:1px solid #1f2730}
+.page-banner{padding:80px 0;text-align:center;position:relative;background:linear-gradient(135deg,rgba(29,185,84,.1),rgba(29,185,84,.03));border-bottom:1px solid #e5e7eb}
 .page-banner::before{content:"";position:absolute;inset:0;background:radial-gradient(circle at top left,rgba(29,185,84,.25),transparent 70%);pointer-events:none}
 .page-banner::after{content:"";position:absolute;left:50%;bottom:0;width:120px;height:3px;background:var(--brand);transform:translateX(-50%);border-radius:2px 2px 0 0}
 .page-banner h1{margin:0;font-size:clamp(2rem,4vw,3rem)}
 .grid.cards{display:grid;grid-template-columns:repeat(4,1fr);gap:18px}
-.card{background:var(--surface);border:1px solid #222c36;border-radius:16px;padding:18px}
+.card{background:var(--surface);border:1px solid #d1d5db;border-radius:16px;padding:18px}
 .grid.featured{display:grid;grid-template-columns:repeat(3,1fr);gap:18px}
-.feature-card{background:var(--surface);border:1px solid #222c36;border-radius:16px;overflow:hidden;display:block;position:relative}
+.feature-card{background:var(--surface);border:1px solid #d1d5db;border-radius:16px;overflow:hidden;display:block;position:relative}
 .feature-meta{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;text-align:center;padding:12px 14px;background:rgba(0,0,0,.55);opacity:0;transition:opacity .3s ease;pointer-events:none}
 .feature-card:hover .feature-meta,.projects-grid a:hover .feature-meta{opacity:1}
 .about-split{display:grid;grid-template-columns:1.2fr .8fr;gap:18px;align-items:center}
@@ -127,10 +127,10 @@ h1,h2,h3{line-height:1.2}
 /* Services landing */
 .services-landing .section-title { margin-bottom: 8px; }
 .select-grid{display:grid;grid-template-columns:1fr 1fr;gap:24px;margin-top:18px}
-.select-card{position:relative;display:block;height:clamp(320px,62vh,560px);border-radius:22px;overflow:hidden;border:1px solid #22303a;background:#0d1217;background-image:var(--card-bg);background-size:cover;background-position:center;transition:transform .35s ease, box-shadow .35s ease, filter .35s ease;box-shadow:0 10px 30px rgba(0,0,0,.35)}
+.select-card{position:relative;display:block;height:clamp(320px,62vh,560px);border-radius:22px;overflow:hidden;border:1px solid #d1d5db;background:#ffffff;background-image:var(--card-bg);background-size:cover;background-position:center;transition:transform .35s ease, box-shadow .35s ease, filter .35s ease;box-shadow:0 10px 30px rgba(0,0,0,.15)}
 .select-card:hover{transform:translateY(-2px);box-shadow:0 16px 40px rgba(0,0,0,.45);filter:brightness(1.02)}
 .select-card__shade{position:absolute;inset:0;background:linear-gradient(to bottom, rgba(0,0,0,.0), rgba(0,0,0,.55));pointer-events:none}
-.select-card__glass{position:absolute;left:20px;right:20px;bottom:20px;padding:14px 16px;border-radius:18px;color:#e8edf2;backdrop-filter:saturate(160%) blur(14px);-webkit-backdrop-filter:saturate(160%) blur(14px);background:rgba(255,255,255,.06);border:1px solid rgba(255,255,255,.22);box-shadow:inset 0 1px 0 rgba(255,255,255,.12),0 8px 24px rgba(0,0,0,.25)}
+.select-card__glass{position:absolute;left:20px;right:20px;bottom:20px;padding:14px 16px;border-radius:18px;color:var(--text);backdrop-filter:saturate(160%) blur(14px);-webkit-backdrop-filter:saturate(160%) blur(14px);background:rgba(255,255,255,.6);border:1px solid rgba(0,0,0,.1);box-shadow:inset 0 1px 0 rgba(255,255,255,.8),0 8px 24px rgba(0,0,0,.1)}
 .select-card__glass h2{margin:0;font-size:clamp(1.4rem,3vw,2rem)}
 .select-card__glass p{display:none}
 
@@ -145,7 +145,7 @@ h1,h2,h3{line-height:1.2}
 
 /* Projects grid */
 .projects-grid{display:grid;grid-template-columns:repeat(2,1fr);gap:16px}
-.projects-grid a{display:block;border:1px solid #22303a;border-radius:14px;overflow:hidden;background:#0d1217;position:relative;aspect-ratio:4/3}
+.projects-grid a{display:block;border:1px solid #d1d5db;border-radius:14px;overflow:hidden;background:#ffffff;position:relative;aspect-ratio:4/3}
 .projects-grid img{width:100%;height:100%;object-fit:cover;display:block}
 .project-video{width:100%;aspect-ratio:16/9;border-radius:14px;margin:0 0 16px;background:#000;display:block}
 .project-desc{margin:16px 0;font-size:1.125rem;font-weight:500;line-height:1.7}
@@ -159,7 +159,7 @@ h1,h2,h3{line-height:1.2}
 .site-footer{padding:48px 0;margin-top:auto}
 .site-footer .brand{margin-bottom:12px}
 .site-footer .footer-grid{display:grid;grid-template-columns:1fr 1fr 1fr;gap:18px}
-.footer-bottom{padding:12px 0;border-top:1px solid #22303a;margin-top:18px}
+.footer-bottom{padding:12px 0;border-top:1px solid #d1d5db;margin-top:18px}
 .footer-bottom .copyright{font-size:.75rem}
 
 /* Responsive */
@@ -173,7 +173,7 @@ h1,h2,h3{line-height:1.2}
 @media (max-width: 640px){
   .grid.cards{grid-template-columns:1fr}
   .menu-btn{display:block}
-  .nav{display:none;position:absolute;right:20px;top:58px;background:#0d1217;border:1px solid #23303a;border-radius:12px;padding:10px;width:220px;flex-direction:column}
+  .nav{display:none;position:absolute;right:20px;top:58px;background:#ffffff;border:1px solid #d1d5db;border-radius:12px;padding:10px;width:220px;flex-direction:column}
   .nav.open{display:flex}
   .nav .dropdown{width:100%}
   .nav .dropdown-menu{position:static;border:none;padding:0;margin-top:8px}
@@ -193,21 +193,21 @@ h1,h2,h3{line-height:1.2}
 .stat-label{text-shadow:0 0 4px rgba(29,185,84,.6)}
 @keyframes neonFlicker{0%,100%{box-shadow:0 0 10px var(--brand),0 0 20px rgba(29,185,84,.6);opacity:1}2%,4%{box-shadow:0 0 2px var(--brand),0 0 4px rgba(29,185,84,.2);opacity:.6}3%,5%{box-shadow:0 0 10px var(--brand),0 0 20px rgba(29,185,84,.6);opacity:1}50%{box-shadow:0 0 12px var(--brand),0 0 24px rgba(29,185,84,.8);opacity:1}51%{box-shadow:0 0 3px var(--brand),0 0 6px rgba(29,185,84,.3);opacity:.7}52%{box-shadow:0 0 12px var(--brand),0 0 24px rgba(29,185,84,.8);opacity:1}70%{box-shadow:0 0 12px var(--brand),0 0 24px rgba(29,185,84,.8);opacity:1}71%{box-shadow:0 0 3px var(--brand),0 0 6px rgba(29,185,84,.3);opacity:.7}72%{box-shadow:0 0 10px var(--brand),0 0 20px rgba(29,185,84,.6);opacity:1}73%{box-shadow:0 0 4px var(--brand),0 0 8px rgba(29,185,84,.4);opacity:.8}75%{box-shadow:0 0 10px var(--brand),0 0 20px rgba(29,185,84,.6);opacity:1}}
 .projects-showcase{display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:18px}
-.project-tile{position:relative;display:block;border:1px solid #222c36;border-radius:16px;overflow:hidden;background:var(--surface);box-shadow:0 10px 30px rgba(0,0,0,.35);transition:transform .35s ease,filter .35s ease}
+.project-tile{position:relative;display:block;border:1px solid #d1d5db;border-radius:16px;overflow:hidden;background:var(--surface);box-shadow:0 10px 30px rgba(0,0,0,.1);transition:transform .35s ease,filter .35s ease}
 .project-tile img{width:100%;aspect-ratio:4/3;object-fit:cover}
 .project-tile .project-meta{position:absolute;left:0;right:0;bottom:0;padding:12px;background:linear-gradient(180deg,rgba(0,0,0,0),rgba(0,0,0,.6))}
 .project-tile:hover,.project-tile:focus{transform:translateY(-2px);filter:brightness(1.05);outline:none}
 .pillars-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:18px;margin-top:24px}
-.pillar-card{background:var(--surface);border:1px solid #222c36;border-radius:16px;padding:24px}
+.pillar-card{background:var(--surface);border:1px solid #d1d5db;border-radius:16px;padding:24px}
 .process-timeline{display:flex;list-style:none;gap:18px;margin:24px 0 0;padding:0}
-.process-timeline li{flex:1;background:var(--surface);border:1px solid #222c36;border-radius:16px;padding:20px;position:relative}
-.process-timeline li:not(:last-child)::after{content:"";position:absolute;top:50%;right:-9px;width:18px;height:2px;background:#222c36;transform:translateY(-50%)}
+.process-timeline li{flex:1;background:var(--surface);border:1px solid #d1d5db;border-radius:16px;padding:20px;position:relative}
+.process-timeline li:not(:last-child)::after{content:"";position:absolute;top:50%;right:-9px;width:18px;height:2px;background:#d1d5db;transform:translateY(-50%)}
 @media (max-width:980px){.process-timeline{flex-direction:column}.process-timeline li:not(:last-child)::after{top:auto;bottom:-9px;left:50%;right:auto;width:2px;height:18px;transform:translateX(-50%)}}
 .cta-band{text-align:center}
 .cta-band p{margin:12px 0 24px}
 .cta-band .btn{margin:4px 8px}
 .service-area{margin-top:24px;display:grid;grid-template-columns:2fr 1fr;gap:24px;align-items:center}
-.service-area img{width:100%;border-radius:16px;border:1px solid #222c36;aspect-ratio:4/3;object-fit:cover}
+.service-area img{width:100%;border-radius:16px;border:1px solid #d1d5db;aspect-ratio:4/3;object-fit:cover}
 .service-area ul{list-style:none;padding:0;margin:0}
 .service-area li{margin:6px 0}
 @media (max-width:980px){.service-area{grid-template-columns:1fr}}


### PR DESCRIPTION
## Summary
- convert global color variables to light palette
- update header and footer components for light styling
- refresh buttons, cards and menus for light surfaces

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a978b6d5588325887eb467d16fee86