### PR TITLE
Fix hero video to stay static during scroll

### DIFF
--- a/style.css
+++ b/style.css
@@ -45,7 +45,7 @@ h1,h2,h3{line-height:1.2}
 .hero-video{position:relative;width:100%;height:100svh;overflow:hidden;background:#0d1217;border-bottom:1px solid #1f2730}
 @supports (height:100dvh){ .hero-video{ height:100dvh; } }
 @supports not (height:100svh){ .hero-video{ height:100vh; } }
-.hero-video .hero-bg{position:absolute;inset:0;width:100%;height:100%;object-fit:cover;filter:brightness(.6);z-index:0}
+.hero-video .hero-bg{position:fixed;inset:0;width:100%;height:100%;object-fit:cover;filter:brightness(.6);z-index:-1}
 .hero-overlay{position:absolute;inset:0;z-index:1;display:flex;flex-direction:column;align-items:flex-start;justify-content:flex-end;text-align:left;padding:0 20px 10vh;overflow:hidden}
 .hero-overlay > *{width:100%;position:relative;z-index:1}
 .hero-overlay::before{content:"";position:absolute;inset:0;background:


### PR DESCRIPTION
## Summary
- Keep hero background video fixed so page scrolls over it without moving the video

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a9798fd7408325ac6bea63e165b492