### PR TITLE
Fix hero overlay disappearing behind video

### DIFF
--- a/style.css
+++ b/style.css
@@ -45,7 +45,7 @@ h1,h2,h3{line-height:1.2}
 .hero-video{position:relative;width:100%;height:100svh;overflow:hidden;background:#0d1217;border-bottom:1px solid #1f2730}
 @supports (height:100dvh){ .hero-video{ height:100dvh; } }
 @supports not (height:100svh){ .hero-video{ height:100vh; } }
-.hero-video .hero-bg{position:fixed;inset:0;width:100%;height:100%;object-fit:cover;filter:brightness(.6);z-index:-1}
+.hero-video .hero-bg{position:absolute;inset:0;width:100%;height:100%;object-fit:cover;filter:brightness(.6);z-index:0}
 .hero-overlay{position:absolute;inset:0;z-index:1;display:flex;flex-direction:column;align-items:flex-start;justify-content:flex-end;text-align:left;padding:0 20px 10vh;overflow:hidden}
 .hero-overlay > *{width:100%;position:relative;z-index:1}
 .hero-overlay::before{content:"";position:absolute;inset:0;background:


### PR DESCRIPTION
## Summary
- ensure hero background video stays behind overlay by using absolute positioning

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a97ad56aa083259040576e085097e0