### PR TITLE
Enhance hero overlay grain for readability

### DIFF
--- a/style.css
+++ b/style.css
@@ -54,7 +54,12 @@ h1,h2,h3{line-height:1.2}
   background-size:cover,200px 200px;
   background-repeat:no-repeat,repeat;
   background-blend-mode:overlay;
-  opacity:.35;
+  opacity:.5;
+  pointer-events:none;
+  z-index:0}
+.hero-overlay::after{content:"";position:absolute;inset:0;background:
+    radial-gradient(circle at 25% 35%, rgba(0,0,0,0.45), transparent 60%),
+    radial-gradient(circle at 75% 65%, rgba(0,0,0,0.35), transparent 55%);
   pointer-events:none;
   z-index:0}
 .hero-copy{font-family:'Garamond',serif;font-size:clamp(2.25rem,5.4vw,3.6rem);line-height:1.1;font-weight:400}


### PR DESCRIPTION
## Summary
- Darken hero banner's grain overlay and add subtle radial “blob” shapes for improved text contrast

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a97c4381f483259f1f233d35caf7e7