### PR TITLE
Fix hero video scroll overlay and nav glide

### DIFF
--- a/includes.js
+++ b/includes.js
@@ -48,9 +48,12 @@ async function applyConfig(){
     // Hero nav glide effect
     const headerEl = document.querySelector('.site-header');
     const hero = document.querySelector('.hero-video');
+    const mainEl = document.querySelector('body.home main');
     if (headerEl && hero){
       const update = () => {
-        const offset = Math.max(hero.getBoundingClientRect().bottom - headerEl.offsetHeight, 0);
+        const heroH = hero.offsetHeight;
+        if (mainEl) mainEl.style.marginTop = heroH + 'px';
+        const offset = Math.max(heroH - window.scrollY - headerEl.offsetHeight, 0);
         headerEl.style.transform = `translateY(${offset}px)`;
       };
       update();

--- a/style.css
+++ b/style.css
@@ -9,7 +9,9 @@ body{display:flex;flex-direction:column}
 a{color:var(--text);text-decoration:none}
 img{max-width:100%;height:auto;display:block}
 main{padding-top:var(--header-h);flex:1}
-body.home main{padding-top:0}
+body.home main{padding-top:var(--header-h);margin-top:100svh;position:relative;z-index:1}
+@supports (height:100dvh){ body.home main{ margin-top:100dvh; } }
+@supports not (height:100svh){ body.home main{ margin-top:100vh; } }
 .container{width:100%;margin:0 auto;padding:0 clamp(20px,5vw,60px)}
 .small{font-size:.92rem}.muted{color:var(--muted)}
 .rounded{border-radius:14px}.shadow{box-shadow:0 10px 30px rgba(0,0,0,.35)}
@@ -42,7 +44,7 @@ h1,h2,h3{line-height:1.2}
 .menu-page nav{display:flex;flex-direction:column;gap:24px;font-size:2rem;text-align:center}
 .menu-page nav a{color:var(--text)}
 /* Hero video */
-.hero-video{position:relative;width:100%;height:100svh;overflow:hidden;background:#0d1217;border-bottom:1px solid #1f2730}
+.hero-video{position:fixed;top:0;left:0;width:100%;height:100svh;overflow:hidden;background:#0d1217;border-bottom:1px solid #1f2730;z-index:0}
 @supports (height:100dvh){ .hero-video{ height:100dvh; } }
 @supports not (height:100svh){ .hero-video{ height:100vh; } }
 .hero-video .hero-bg{position:absolute;inset:0;width:100%;height:100%;object-fit:cover;filter:brightness(.6);z-index:0}


### PR DESCRIPTION
## Summary
- Keep hero video fixed while page content scrolls over it
- Slide navbar up from bottom of hero and pin it to top after scrolling

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a97d31c15c832585b801168098e7f3