### PR TITLE
Remove unused stats sections

### DIFF
--- a/flat-roofing.html
+++ b/flat-roofing.html
@@ -22,11 +22,6 @@
           <li>Reinforced base sheet with protective cap sheet finish</li>
         </ul>
         <p>Typical service life: 25–30 years with proper maintenance.</p>
-        <div class="stats-grid">
-          <div class="stat"><span class="stat-number">2‑Ply</span><p class="stat-label small">SBS Membrane</p></div>
-          <div class="stat"><span class="stat-number">Flame‑Free</span><p class="stat-label small">Options Available</p></div>
-          <div class="stat"><span class="stat-number">30 yrs</span><p class="stat-label small">Max Lifespan</p></div>
-        </div>
         <section class="cta-band">
           <p>Ready to discuss your flat roofing project?</p>
           <a class="btn primary" href="contact.html">Request a Quote</a>

--- a/index.html
+++ b/index.html
@@ -39,19 +39,6 @@
         </div>
       </section>
 
-    <!-- Impact Statement + Stats -->
-    <section class="section impact" aria-labelledby="impact-title">
-      <div class="container">
-        <h2 id="impact-title">Building &amp; Protecting Large‑Scale Roofs Across the West Coast</h2>
-        <div class="stats-grid">
-          <div class="stat reveal"><span class="stat-number">25+</span><p class="stat-label small">Years Delivering Complex Projects</p></div>
-          <div class="stat reveal"><span class="stat-number">5M+</span><p class="stat-label small">sq ft Installed</p></div>
-          <div class="stat reveal"><span class="stat-number">180k</span><p class="stat-label small">Largest Single Project (sq ft)</p></div>
-          <div class="stat reveal"><span class="stat-number">Licensed</span><p class="stat-label small">Insured • COR‑Aligned Safety</p></div>
-        </div>
-      </div>
-    </section>
-
     <!-- Signature Projects Showcase -->
     <section class="section projects" aria-labelledby="projects-title">
       <div class="container">

--- a/metal-roofing.html
+++ b/metal-roofing.html
@@ -21,11 +21,6 @@
           <li>Floating clip systems allow for thermal expansion</li>
         </ul>
         <p>Typical service life: 40–50 years with minimal maintenance.</p>
-        <div class="stats-grid">
-          <div class="stat"><span class="stat-number">24ga</span><p class="stat-label small">Steel Panels</p></div>
-          <div class="stat"><span class="stat-number">No Exposed</span><p class="stat-label small">Fasteners</p></div>
-          <div class="stat"><span class="stat-number">50 yrs</span><p class="stat-label small">Max Lifespan</p></div>
-        </div>
         <section class="cta-band">
           <p>Interested in standing seam metal roofing?</p>
           <a class="btn primary" href="contact.html">Request a Quote</a>

--- a/style.css
+++ b/style.css
@@ -166,10 +166,6 @@ h1,h2,h3{line-height:1.2}
 .reveal{opacity:0;transform:translateY(16px);transition:opacity .35s ease,transform .35s ease}
 .reveal.in{opacity:1;transform:none}
 @media (prefers-reduced-motion:reduce){.reveal{opacity:1!important;transform:none!important;transition:none!important}}
-.stats-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(160px,1fr));gap:24px;text-align:center;margin-top:24px}
-.stat{position:relative;padding:20px;border-radius:12px;border:1px solid var(--brand);background:rgba(0,0,0,.4)}
-.stat::after{content:"";position:absolute;inset:0;background:repeating-linear-gradient(45deg,rgba(255,255,255,.05)0 2px,transparent 2px 4px);mix-blend-mode:overlay;pointer-events:none}
-.stat-number{display:block;font-size:clamp(1.8rem,4vw,2.6rem);font-weight:700;margin-bottom:6px;color:var(--brand)}
 .projects-showcase{display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:18px}
 .project-tile{position:relative;display:block;border:1px solid #222c36;border-radius:16px;overflow:hidden;background:var(--surface);box-shadow:0 10px 30px rgba(0,0,0,.35);transition:transform .35s ease,filter .35s ease}
 .project-tile img{width:100%;aspect-ratio:4/3;object-fit:cover}


### PR DESCRIPTION
## Summary
- Drop impact stats section from homepage
- Remove stats blocks from metal roofing and flat roofing pages
- Clean up CSS for deleted stats components

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a9843ec6508325b81893264b8f1346